### PR TITLE
[FEAT]: Configure Role-Based Permissions for Tables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_METADATA_DEFAULTS: '{"backend_configs":{"dataconnector":{"athena":{"uri":"http://data-connector-agent:8081/api/v1/athena"},"mariadb":{"uri":"http://data-connector-agent:8081/api/v1/mariadb"},"mysql8":{"uri":"http://data-connector-agent:8081/api/v1/mysql"},"oracle":{"uri":"http://data-connector-agent:8081/api/v1/oracle"},"snowflake":{"uri":"http://data-connector-agent:8081/api/v1/snowflake"}}}}'
+      HASURA_GRAPHQL_JWT_SECRET: '{"type":"RS256","jwk_url":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com","claims_map":{"x-hasura-allowed-roles":{"path":"$.roles"},"x-hasura-default-role":{"path":"$.role"},"x-hasura-user-id":{"path":"$.user_id"}}}'
     depends_on:
       postgres:
         condition: service_healthy

--- a/metadata/databases/safetrust/tables/public_apartment_contracts.yaml
+++ b/metadata/databases/safetrust/tables/public_apartment_contracts.yaml
@@ -1,0 +1,70 @@
+table:
+  name: apartment_contracts
+  schema: public
+
+object_relationships:
+  - name: apartment
+    using:
+      foreign_key_constraint_on: apartment_id
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - apartment_id
+        - tenant_id
+        - start_date
+        - end_date
+        - status
+        - rent_amount
+        - security_deposit
+        - terms_conditions
+        - created_at
+        - updated_at
+      filter:
+        tenant_id:
+          _eq: X-Hasura-User-Id
+    comment: "Tenants can view their own contracts"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - apartment_id
+        - tenant_id
+        - start_date
+        - end_date
+        - status
+        - rent_amount
+        - security_deposit
+        - terms_conditions
+        - created_at
+        - updated_at
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+    comment: "Landlords can view contracts for their properties"
+
+update_permissions:
+  - role: landlord
+    permission:
+      columns:
+        - status
+        - terms_conditions
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+        status:
+          _in: ["DRAFT", "PENDING"]
+      check:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+    comment: "Landlords can update contract status and terms for their properties"

--- a/metadata/databases/safetrust/tables/public_apartment_images.yaml
+++ b/metadata/databases/safetrust/tables/public_apartment_images.yaml
@@ -1,3 +1,56 @@
 table:
   name: apartment_images
   schema: public
+
+object_relationships:
+  - name: apartment
+    using:
+      foreign_key_constraint_on: apartment_id
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - apartment_id
+        - image_url
+        - uploaded_at
+      filter:
+        apartment:
+          is_available:
+            _eq: true
+          deleted_at:
+            _is_null: true
+    comment: "Tenants can view images of available apartments"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - apartment_id
+        - image_url
+        - uploaded_at
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+    comment: "Landlords can view images of their own apartments"
+
+update_permissions:
+  - role: landlord
+    permission:
+      columns:
+        - image_url
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+      check:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+    comment: "Landlords can update images of their own apartments"

--- a/metadata/databases/safetrust/tables/public_apartments.yaml
+++ b/metadata/databases/safetrust/tables/public_apartments.yaml
@@ -1,0 +1,99 @@
+table:
+  name: apartments
+  schema: public
+
+array_relationships:
+  - name: apartment_images
+    using:
+      foreign_key_constraint_on:
+        column: apartment_id
+        table:
+          name: apartment_images
+          schema: public
+  - name: bid_requests
+    using:
+      foreign_key_constraint_on:
+        column: apartment_id
+        table:
+          name: bid_requests
+          schema: public
+  - name: apartment_contracts
+    using:
+      foreign_key_constraint_on:
+        column: apartment_id
+        table:
+          name: apartment_contracts
+          schema: public
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - owner_id
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - location_area
+        - address
+        - is_available
+        - available_from
+        - available_until
+        - created_at
+      filter:
+        is_available:
+          _eq: true
+        deleted_at:
+          _is_null: true
+    comment: "Tenants can view all available apartments"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - owner_id
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - location_area
+        - address
+        - is_available
+        - available_from
+        - available_until
+        - created_at
+        - updated_at
+        - deleted_at
+      filter:
+        owner_id:
+          _eq: X-Hasura-User-Id
+    comment: "Landlords can view their own apartments"
+
+update_permissions:
+  - role: landlord
+    permission:
+      columns:
+        - name
+        - description
+        - price
+        - warranty_deposit
+        - coordinates
+        - location_area
+        - address
+        - is_available
+        - available_from
+        - available_until
+      filter:
+        owner_id:
+          _eq: X-Hasura-User-Id
+      check:
+        owner_id:
+          _eq: X-Hasura-User-Id
+    comment: "Landlords can update their own apartments"

--- a/metadata/databases/safetrust/tables/public_bid_requests.yaml
+++ b/metadata/databases/safetrust/tables/public_bid_requests.yaml
@@ -1,0 +1,108 @@
+table:
+  name: bid_requests
+  schema: public
+
+object_relationships:
+  - name: apartment
+    using:
+      foreign_key_constraint_on: apartment_id
+  - name: tenant
+    using:
+      foreign_key_constraint_on: tenant_id
+
+array_relationships:
+  - name: bid_status_histories
+    using:
+      foreign_key_constraint_on:
+        column: bid_request_id
+        table:
+          name: bid_status_histories
+          schema: public
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - apartment_id
+        - tenant_id
+        - current_status
+        - proposed_price
+        - desired_move_in
+        - created_at
+        - updated_at
+      filter:
+        tenant_id:
+          _eq: X-Hasura-User-Id
+        deleted_at:
+          _is_null: true
+    comment: "Tenants can view their own bid requests"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - apartment_id
+        - tenant_id
+        - current_status
+        - proposed_price
+        - desired_move_in
+        - created_at
+        - updated_at
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+        deleted_at:
+          _is_null: true
+    comment: "Landlords can view bid requests for their apartments"
+
+update_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - proposed_price
+        - desired_move_in
+      filter:
+        _and:
+          - tenant_id:
+              _eq: X-Hasura-User-Id
+          - current_status:
+              _in: ["DRAFT", "PENDING"]
+          - deleted_at:
+              _is_null: true
+      check:
+        tenant_id:
+          _eq: X-Hasura-User-Id
+    comment: "Tenants can update their own pending bid requests"
+  - role: landlord
+    permission:
+      columns:
+        - current_status
+      filter:
+        apartment:
+          owner_id:
+            _eq: X-Hasura-User-Id
+        deleted_at:
+          _is_null: true
+      check: {}
+    comment: "Landlords can update status of bid requests for their apartments"
+
+insert_permissions:
+  - role: tenant
+    permission:
+      check:
+        tenant_id:
+          _eq: X-Hasura-User-Id
+      columns:
+        - apartment_id
+        - proposed_price
+        - desired_move_in
+      set:
+        tenant_id: X-Hasura-User-Id
+        current_status: "DRAFT"
+    comment: "Tenants can create new bid requests"

--- a/metadata/databases/safetrust/tables/public_bid_status_histories.yaml
+++ b/metadata/databases/safetrust/tables/public_bid_status_histories.yaml
@@ -1,0 +1,73 @@
+table:
+  name: bid_status_histories
+  schema: public
+
+object_relationships:
+  - name: bid_request
+    using:
+      foreign_key_constraint_on: bid_request_id
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - bid_request_id
+        - status
+        - notes
+        - changed_by
+        - created_at
+      filter:
+        bid_request:
+          tenant_id:
+            _eq: X-Hasura-User-Id
+    comment: "Tenants can view status history of their own bids"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - bid_request_id
+        - status
+        - notes
+        - changed_by
+        - created_at
+      filter:
+        bid_request:
+          apartment:
+            owner_id:
+              _eq: X-Hasura-User-Id
+    comment: "Landlords can view status history of bids on their properties"
+
+insert_permissions:
+  - role: tenant
+    permission:
+      check:
+        bid_request:
+          tenant_id:
+            _eq: X-Hasura-User-Id
+      columns:
+        - bid_request_id
+        - status
+        - notes
+      set:
+        changed_by: X-Hasura-User-Id
+    comment: "Tenants can add status history when updating their bids"
+  - role: landlord
+    permission:
+      check:
+        bid_request:
+          apartment:
+            owner_id:
+              _eq: X-Hasura-User-Id
+      columns:
+        - bid_request_id
+        - status
+        - notes
+      set:
+        changed_by: X-Hasura-User-Id
+    comment: "Landlords can add status history when responding to bids"

--- a/metadata/databases/safetrust/tables/public_escrow_api_calls.yaml
+++ b/metadata/databases/safetrust/tables/public_escrow_api_calls.yaml
@@ -1,0 +1,46 @@
+table:
+  name: escrow_api_calls
+  schema: public
+
+object_relationships:
+  - name: escrow_transaction
+    using:
+      foreign_key_constraint_on: escrow_transaction_id
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - escrow_transaction_id
+        - endpoint
+        - method
+        - http_status_code
+        - created_at
+      filter:
+        escrow_transaction:
+          bid_request:
+            tenant_id:
+              _eq: X-Hasura-User-Id
+    comment: "Tenants can view basic status of API calls related to their transactions"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - escrow_transaction_id
+        - endpoint
+        - method
+        - http_status_code
+        - created_at
+      filter:
+        escrow_transaction:
+          bid_request:
+            apartment:
+              owner_id:
+                _eq: X-Hasura-User-Id
+    comment: "Landlords can view basic status of API calls related to their properties"

--- a/metadata/databases/safetrust/tables/public_escrow_transactions.yaml
+++ b/metadata/databases/safetrust/tables/public_escrow_transactions.yaml
@@ -1,0 +1,109 @@
+table:
+  name: escrow_transactions
+  schema: public
+
+object_relationships:
+  - name: bid_request
+    using:
+      foreign_key_constraint_on: bid_request_id
+
+array_relationships:
+  - name: escrow_xdr_transactions
+    using:
+      foreign_key_constraint_on:
+        column: escrow_transaction_id
+        table:
+          name: escrow_xdr_transactions
+          schema: public
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - bid_request_id
+        - engagement_id
+        - contract_id
+        - transaction_type
+        - status
+        - amount
+        - initial_deposit_percentage
+        - cancellation_reason
+        - cancelled_by
+        - refund_status
+        - created_at
+        - updated_at
+        - completed_at
+      filter:
+        bid_request:
+          tenant_id:
+            _eq: X-Hasura-User-Id
+    comment: "Tenants can view their own escrow transactions"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - bid_request_id
+        - engagement_id
+        - contract_id
+        - transaction_type
+        - status
+        - amount
+        - initial_deposit_percentage
+        - cancellation_reason
+        - cancelled_by
+        - refund_status
+        - created_at
+        - updated_at
+        - completed_at
+      filter:
+        bid_request:
+          apartment:
+            owner_id:
+              _eq: X-Hasura-User-Id
+    comment: "Landlords can view escrow transactions for their properties"
+
+update_permissions:
+  - role: tenant
+    permission:
+      columns:
+        - cancellation_reason
+      filter:
+        _and:
+          - bid_request:
+              tenant_id:
+                _eq: X-Hasura-User-Id
+          - status:
+              _in: ["PENDING", "INITIATED"]
+      check:
+        bid_request:
+          tenant_id:
+            _eq: X-Hasura-User-Id
+      set:
+        cancelled_by: X-Hasura-User-Id
+    comment: "Tenants can only cancel their pending transactions"
+  - role: landlord
+    permission:
+      columns:
+        - cancellation_reason
+      filter:
+        _and:
+          - bid_request:
+              apartment:
+                owner_id:
+                  _eq: X-Hasura-User-Id
+          - status:
+              _in: ["PENDING", "INITIATED"]
+      check:
+        bid_request:
+          apartment:
+            owner_id:
+              _eq: X-Hasura-User-Id
+      set:
+        cancelled_by: X-Hasura-User-Id
+    comment: "Landlords can only cancel pending transactions"

--- a/metadata/databases/safetrust/tables/public_escrow_xdr_transactions.yaml
+++ b/metadata/databases/safetrust/tables/public_escrow_xdr_transactions.yaml
@@ -1,0 +1,48 @@
+table:
+  name: escrow_xdr_transactions
+  schema: public
+
+object_relationships:
+  - name: escrow_transaction
+    using:
+      foreign_key_constraint_on: escrow_transaction_id
+
+select_permissions:
+  - role: anonymous
+    permission:
+      columns: []
+      filter: {}
+    comment: ""
+  - role: tenant
+    permission:
+      columns:
+        - id
+        - escrow_transaction_id
+        - xdr_type
+        - status
+        - signing_address
+        - created_at
+        - updated_at
+      filter:
+        escrow_transaction:
+          bid_request:
+            tenant_id:
+              _eq: X-Hasura-User-Id
+    comment: "Tenants can view limited details of their own XDR transactions"
+  - role: landlord
+    permission:
+      columns:
+        - id
+        - escrow_transaction_id
+        - xdr_type
+        - status
+        - signing_address
+        - created_at
+        - updated_at
+      filter:
+        escrow_transaction:
+          bid_request:
+            apartment:
+              owner_id:
+                _eq: X-Hasura-User-Id
+    comment: "Landlords can view limited details of XDR transactions for their properties"


### PR DESCRIPTION
# 📝 Configure Role-Based Permissions for Tables
## 🛠️ Issue
- Closes #84 
## 📖 Description

Implemented role-based access control (RBAC) for all database tables through dedicated YAML files, following the established pattern from the users table. Changes include:

- public_apartments.yaml
- public_apartment_images.yaml
- public_bid_requests.yaml
- public_bid_status_histories.yaml
- public_escrow_transactions.yaml
- public_escrow_xdr_transactions.yaml
- public_escrow_api_calls.yaml
- public_apartment_contracts.yaml

## 📝 Additional Notes
- All permission files follow the pattern established in the users table permissions
- JWT configuration enables Firebase authentication integration
- Changes maintain backward compatibility with existing functionality