### PR TITLE
feat(auth-service): add initial authentication service with login end…

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3001
+
+CMD ["node", "index.js"]

--- a/auth-service/index.js
+++ b/auth-service/index.js
@@ -1,0 +1,58 @@
+const express = require("express");
+const jwt = require("jsonwebtoken");
+const bcrypt = require("bcrypt");
+const { request, gql } = require("graphql-request");
+
+const app = express();
+app.use(express.json());
+
+app.post("/login", async (req, res) => {
+  try {
+    const { email, password } = req.body;
+
+    const query = gql`
+      query GetUser($email: String!) {
+        users(where: { email: { _eq: $email } }) {
+          id
+          password
+        }
+      }
+    `;
+
+    const response = await request(
+      process.env.HASURA_ENDPOINT,
+      query,
+      { email },
+      {
+        "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET,
+      }
+    );
+
+    const user = response.users[0];
+
+    if (!user || !bcrypt.compareSync(password, user.password)) {
+      return res.status(401).json({ error: "Invalid credentials" });
+    }
+
+    const token = jwt.sign(
+      {
+        hasura: {
+          "x-hasura-allowed-roles": ["user"],
+          "x-hasura-default-role": "user",
+          "x-hasura-user-id": user.id,
+        },
+      },
+      process.env.JWT_SECRET,
+      { expiresIn: "1d" }
+    );
+
+    res.json({ token });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+app.listen(3001, () => {
+  console.log("Auth service running on port 3001");
+});

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "auth-service",
+    "version": "1.0.0",
+    "main": "index.js",
+    "dependencies": {
+      "bcrypt": "^5.1.0",
+      "express": "^4.18.2",
+      "graphql-request": "^6.1.0",
+      "jsonwebtoken": "^9.0.0"
+    }
+  }
+  


### PR DESCRIPTION
# 🔐 JWT Auth Integration – Part 1: Setup & Auth Service

## ✅ Overview

This PR adds secure JWT-based authentication to Hasura using a custom Node.js service and Docker. It enables role-based access via embedded claims and sets up the project for user authentication workflows.
## ⚙️ Hasura Setup

- JWT configured via `HASURA_GRAPHQL_JWT_SECRET` (HS256)
- Claims use: `$.hasura` as namespace path
- Admin secret enforced via `HASURA_GRAPHQL_ADMIN_SECRET`
- Unauthorized users default to `anonymous`

```yaml
HASURA_GRAPHQL_JWT_SECRET: '{
  "type": "HS256",
  "key": "myjwtsecretkeyhere",
  "claims_namespace_path": "$.hasura"
}'
```

---

## 🛠 Auth Service (`auth-service`)

- Built in Node.js + Express
- Login route: `POST /login`
- Validates credentials via Hasura Admin API
- Compares hashed password using `bcrypt`
- Returns a JWT like:

```json
{
  "hasura": {
    "x-hasura-allowed-roles": ["user"],
    "x-hasura-default-role": "user",
    "x-hasura-user-id": "user-id"
  }
}
```