### PR TITLE
feat: implement escrow_transactions migration

### DIFF
--- a/migrations/hotel_industry/1745664202192_create_escrow_transactions/down.sql
+++ b/migrations/hotel_industry/1745664202192_create_escrow_transactions/down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_escrow_transactions_reservation;
+DROP INDEX IF EXISTS idx_escrow_transactions_status;
+DROP INDEX IF EXISTS idx_escrow_transactions_type;
+DROP INDEX IF EXISTS idx_escrow_transactions_created_at;
+
+DROP TABLE IF EXISTS escrow_transactions;

--- a/migrations/hotel_industry/1745664202192_create_escrow_transactions/up.sql
+++ b/migrations/hotel_industry/1745664202192_create_escrow_transactions/up.sql
@@ -1,0 +1,31 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE escrow_transactions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    -- Foreign key relationships will be added later when related tables are ready
+    escrow_transaction_id UUID,
+    reservation_id UUID,
+    contract_id TEXT,
+    escrow_status VARCHAR(200) DEFAULT 'PENDING',
+    signer_address VARCHAR(200),
+    transaction_type VARCHAR(150),
+    escrow_transaction_type VARCHAR(150),
+    http_status_code INTEGER,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX idx_escrow_transactions_reservation ON escrow_transactions(reservation_id);
+CREATE INDEX idx_escrow_transactions_status ON escrow_transactions(escrow_status);
+CREATE INDEX idx_escrow_transactions_type ON escrow_transactions(transaction_type);
+CREATE INDEX idx_escrow_transactions_created_at ON escrow_transactions(created_at);
+
+-- 
+-- TODO: Add foreign keys later when the related tables are created:
+--
+-- ALTER TABLE escrow_transactions
+--   ADD CONSTRAINT fk_escrow_transaction_user FOREIGN KEY (escrow_transaction_id) REFERENCES escrow_transaction_users(id);
+--
+-- ALTER TABLE escrow_transactions
+--   ADD CONSTRAINT fk_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id);
+--

--- a/seeds/hotel_industry/escrow_transactions.sql
+++ b/seeds/hotel_industry/escrow_transactions.sql
@@ -1,0 +1,27 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+
+-- SET search_path TO public;
+
+-- Insert sample data into the escrow_transactions table
+INSERT INTO escrow_transactions (
+    escrow_transaction_id, 
+    reservation_id, 
+    contract_id, 
+    signer_address, 
+    transaction_type, 
+    escrow_transaction_type, 
+    escrow_status,
+    http_status_code
+) 
+VALUES 
+    (
+        uuid_generate_v4(), 
+        uuid_generate_v4(), 
+        'contract_001', 
+        '0x123abc', 
+        'CREATE_ESCROW', 
+        'CREATE_ESCROW', 
+        'PENDING', 
+        200
+    );


### PR DESCRIPTION
Closes #135 

# Add `escrow_transactions` table

## Description:
This PR implements the creation of the `escrow_transactions` table and its associated seed data for the escrow system. The table is created in the `public` schema, and a seed file has been added to populate initial data for testing purposes.

## Changes:
- [x] Feature
- Created `escrow_transactions` migration.

The table contains the following fields:

- `id` (UUID, Primary Key)
- `escrow_transaction_id` (UUID, Foreign Key to `escrow_transaction_users` – left blank as this schema is yet to be created by other contributors)
- `reservation_id` (UUID, Foreign Key to `reservations` – left blank as this schema is yet to be created by other contributors)
- `contract_id` (TEXT)
- `escrow_status` (VARCHAR, default: 'PENDING')
- `signer_address` (VARCHAR)
- `transaction_type` (VARCHAR)
- `escrow_transaction_type` (VARCHAR)
- `http_status_code` (INTEGER)
- `created_at` (TIMESTAMP)
- `updated_at` (TIMESTAMP)

- Added a seeding script for inserting test data into `seeds/hotel_industry/escrow_transactions`.

**Note**: The references to `escrow_transaction_users` and `reservations` are left blank since the schemas for these tables are yet to be created by other contributors.

## How to Test:
1. Run the migration script to create the table.
2. Use the seed script to insert test data:

    ```bash
    docker exec -it backend-safetrust-postgres-1 psql -U postgres -d postgres -f /docker-entrypoint-initdb.d/escrow_transactions.sql
    ```

3. Verify that the table is created and contains the seeded data:

    ```bash
    docker exec -it backend-safetrust-postgres-1 psql -U postgres -d postgres -c "SELECT * FROM escrow_transactions;"
    ```

## Checklist:
- [x] Created the `escrow_transactions` table in the `public` schema.
- [x] Added seed data for `escrow_transactions`.
- [x] Left references to `escrow_transaction_users` and `reservations` as blanks, to be filled by other contributors.
- [x] Tested that the table was successfully created and data was inserted.

# Screenshots
![image](https://github.com/user-attachments/assets/0a1afb0d-f7dd-421c-8b23-6d683120bd71)
![image](https://github.com/user-attachments/assets/68fd318f-eac0-43bc-bfdc-8e18a6922d13)

