### PR TITLE
feat: create room_types table migration

### DIFF
--- a/migrations/hotel_industry/1744160264003_create_room_types/down.sql
+++ b/migrations/hotel_industry/1744160264003_create_room_types/down.sql
@@ -1,0 +1,14 @@
+-- Drop policies
+DROP POLICY IF EXISTS "Users can read room types" ON public.room_types;
+DROP POLICY IF EXISTS "Admins can manage room types" ON public.room_types;
+
+-- Revoke permissions
+REVOKE ALL ON public.room_types FROM admin;
+REVOKE SELECT ON public.room_types FROM service_role;
+REVOKE SELECT ON public.room_types FROM authenticated;
+
+-- Drop index
+DROP INDEX IF EXISTS idx_type_id;
+
+-- Drop table
+DROP TABLE IF EXISTS public.room_types; 

--- a/migrations/hotel_industry/1744160264003_create_room_types/up.sql
+++ b/migrations/hotel_industry/1744160264003_create_room_types/up.sql
@@ -1,0 +1,31 @@
+-- Create room_types table
+CREATE TABLE public.room_types (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    type_id UUID,
+    name VARCHAR(25) NOT NULL
+);
+
+-- Create index on type_id
+CREATE INDEX idx_type_id ON public.room_types(type_id);
+
+-- Grant permissions
+GRANT SELECT ON public.room_types TO authenticated;
+GRANT SELECT ON public.room_types TO service_role;
+GRANT ALL ON public.room_types TO admin;
+
+-- Add RLS policies
+ALTER TABLE public.room_types ENABLE ROW LEVEL SECURITY;
+
+-- Policy for users to read room types
+CREATE POLICY "Users can read room types"
+    ON public.room_types
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+-- Policy for admins to manage room types
+CREATE POLICY "Admins can manage room types"
+    ON public.room_types
+    TO admin
+    USING (true)
+    WITH CHECK (true); 


### PR DESCRIPTION
# Create room_types table migration

## Description
This PR implements the room_types table in the public schema to define all possible room types that a hotel room can have. The table includes a UUID primary key, an additional type identifier, and a human-readable name, along with proper permissions and indexing.

Closes #140 

## Changes Made
- Created `room_types` table with the following structure:
  - `id`: UUID PRIMARY KEY (auto-generated)
  - `type_id`: UUID (for external referencing)
  - `name`: VARCHAR(25) NOT NULL
- Added index `idx_type_id` on the `type_id` column for improved lookup performance
- Implemented Row Level Security (RLS) policies:
  - Users can read room types
  - Admins have full CRUD permissions
- Set up proper permissions:
  - SELECT permission for authenticated users
  - SELECT permission for service_role
  - ALL permissions for admin role

![Screenshot 2025-04-29 at 9 30 00 AM](https://github.com/user-attachments/assets/bf5e94f2-27e5-41c8-b7e5-414117652e14)

## Related Issues
- Related to issue: Create SQL migration files for the hotel_industry tenant users_wallets #112
- Related to issue: Create the rooms table in the hotel_industry tenant #138

## Checklist
- [x] Followed the project's SQL migration guidelines
- [x] Added proper permissions and RLS policies
- [x] Created necessary indexes for performance
- [x] Included both up.sql and down.sql migrations
- [x] Followed atomic commit guidelines