### PR TITLE
🔧 Fix: duplicate index name in the `room_images`  table 

### DIFF
--- a/migrations/hotel_industry/1746439500253_create-room-images/up.sql
+++ b/migrations/hotel_industry/1746439500253_create-room-images/up.sql
@@ -8,4 +8,4 @@ CREATE TABLE room_images (
     uploaded_at TIMESTAMPTZ DEFAULT NOW()
 );
 
-CREATE INDEX idx_room_id ON room_images (room_id);
+CREATE INDEX idx_room_image_id ON room_images (room_id);

--- a/migrations/hotel_industry/1747000000000_create_reservations/up.sql
+++ b/migrations/hotel_industry/1747000000000_create_reservations/up.sql
@@ -16,6 +16,6 @@ CREATE TABLE reservations (
 );
 
 CREATE INDEX idx_user_id ON reservations(wallet_address);
-CREATE INDEX idx_room_id ON reservations(room_id);
+CREATE INDEX idx_room_reservation_id ON reservations(room_id);
 CREATE INDEX idx_reservation_status ON reservations(reservation_status);
 CREATE INDEX idx_reservation_dates ON reservations(check_in, check_out);


### PR DESCRIPTION
## Description
Fix some duplicate index constraint in the `room_images` table; it was rename to make it work.

## Result 
solve the error `index name already exists`

![Screenshot from 2025-07-09 00-10-15](https://github.com/user-attachments/assets/67eb23a9-989e-4bbd-bfd5-86975ea45eca)
![Screenshot from 2025-07-08 23-01-31](https://github.com/user-attachments/assets/cfcafc5e-da39-4091-b59d-a7b0ab43c3e7)
![Screenshot from 2025-07-09 00-11-35](https://github.com/user-attachments/assets/e6ec4306-0e14-41c0-9b8b-7ee834e28436)

## Steps

- Deploy the metadata tenant `hotel_industry` 
- Run `hasura migrate apply --admin-secret myadminsecretkey`

