### PR TITLE
feat(database): add room images seed data for hotel_industry tenant

### DIFF
--- a/seeds/hotel_industry/07_room_images_seed.sql
+++ b/seeds/hotel_industry/07_room_images_seed.sql
@@ -1,0 +1,58 @@
+-- Room Images seed data for hotel_industry tenant
+-- This file populates the room_images table with sample data for testing and development
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Insert all room images in a single statement
+INSERT INTO room_images (room_id, image_url, uploaded_at)
+VALUES
+-- Images for Grand Hotel Room 101 (Deluxe)
+((SELECT room_id FROM rooms WHERE room_number = '101' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1631049307264-da0ec9d70304?w=800', 
+ '2024-07-15 10:30:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '101' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1596394516093-501ba68a0ba6?w=800', 
+ '2024-07-15 10:35:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '101' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1564501049412-61c2a3083791?w=800', 
+ '2024-07-15 10:40:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '101' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?w=800', 
+ '2024-07-15 10:45:00+00'),
+
+-- Images for Grand Hotel Room 102 (Standard)
+((SELECT room_id FROM rooms WHERE room_number = '102' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1611892440504-42a792e24d32?w=800', 
+ '2024-07-16 14:20:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '102' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1590490360182-c33d57733427?w=800', 
+ '2024-07-16 14:25:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '102' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Grand Hotel' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1571003123894-1f0594d2b5d9?w=800', 
+ '2024-07-16 14:30:00+00'),
+
+-- Images for Cozy Inn Room 201 (Suite)
+((SELECT room_id FROM rooms WHERE room_number = '201' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Cozy Inn' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1568495248636-6432b97bd949?w=800', 
+ '2024-07-18 09:15:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '201' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Cozy Inn' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1584132967334-10e028bd69f7?w=800', 
+ '2024-07-18 09:20:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '201' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Cozy Inn' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?w=800', 
+ '2024-07-18 09:25:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '201' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Cozy Inn' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1571003123894-1f0594d2b5d9?w=800', 
+ '2024-07-18 09:30:00+00'),
+
+((SELECT room_id FROM rooms WHERE room_number = '201' AND hotel_id = (SELECT id FROM hotels WHERE name = 'Cozy Inn' LIMIT 1) LIMIT 1), 
+ 'https://images.unsplash.com/photo-1568495248636-6432b97bd949?w=800', 
+ '2024-07-18 09:35:00+00'); 


### PR DESCRIPTION
# Pull Request for 🌱Create seed data for the room_images table in the hotel_industry tenant](https://github.com/safetrustcr/backend-SafeTrust/issues/171) 

❗ **Pull Request Information**
This pull request implements seed data for the room_images table in the hotel_industry tenant to resolve Issue #171. The implementation provides realistic sample room image records for testing and development purposes.

## � Summary of Changes
- Added 07_room_images_seed.sql: Created comprehensive seed data file with 12 sample room images
- Multiple images per room
- Realistic image URLs
- Proper foreign key references: Implemented subqueries to correctly reference existing rooms and hotels
- Varied upload timestamps: Added realistic timestamp distribution for data authenticity
- Coverage for all room types: Deluxe, Standard, and Suite room types included
- Multiple hotels

## 🛠 Testing

### Evidence Before Solution
- Issue: Room listings appeared without visual content for testing
- Problem: No sample images available for room gallery functionality development
- Impact: Missing visual content for different room types and scenarios
- Database State: room_images table existed but was empty

### Evidence After Solution 
<img width="811" height="98" alt="image" src="https://github.com/user-attachments/assets/ab5b64a4-9603-4f3f-a040-b2780472c8e8" />

 ✅ Seed file created: seeds/hotel_industry/07_room_images_seed.sql successfully added
 ✅ Successful application: hasura seed apply command executed without errors
 ✅ Data populated: 12 room images successfully created in database
 ✅ GraphQL queries working: All test queries execute without errors
 ✅ Foreign key structure: Proper references to rooms and hotels implemented
 ✅ Realistic data: Unsplash URLs with varied timestamps for authentic testing

Note: To run optional tests, require #173.

## 📂 Related Issue
This pull request will close #171 upon merging.

