### PR TITLE
chore: added seed data for tenant pricing override

### DIFF
--- a/seeds/shared/1754740128395_tenant_pricing_overrides_seed.sql
+++ b/seeds/shared/1754740128395_tenant_pricing_overrides_seed.sql
@@ -1,0 +1,27 @@
+-- Insert a tenant-specific override for the platform fee on USDC
+-- This demonstrates how a specific tenant can have unique pricing
+INSERT INTO shared.tenant_pricing_overrides (tenant_id, pricing_rule_id, override_percentage)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::UUID, -- Placeholder tenant_id
+    id,
+    0.015 -- New percentage (1.5%) instead of default 2.5%
+FROM shared.pricing_rules
+WHERE rule_name = 'platform_fee_usdc';
+
+-- Insert another example override for XLM platform fee
+INSERT INTO shared.tenant_pricing_overrides (tenant_id, pricing_rule_id, override_percentage)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::UUID, -- Same placeholder tenant_id
+    id,
+    0.020 -- New percentage (2.0%) instead of default 2.5%
+FROM shared.pricing_rules
+WHERE rule_name = 'platform_fee_xlm';
+
+-- Insert a different tenant with different overrides to show variety
+INSERT INTO shared.tenant_pricing_overrides (tenant_id, pricing_rule_id, override_percentage)
+SELECT
+    '660e8400-e29b-41d4-a716-446655440001'::UUID, -- Different placeholder tenant_id
+    id,
+    0.030 -- Higher percentage (3.0%) for premium tenant
+FROM shared.pricing_rules
+WHERE rule_name = 'platform_fee_usdc';


### PR DESCRIPTION
##  Add Tenant Pricing Overrides Seed Data

###  **Summary**
Adds practical seed data to the `shared.tenant_pricing_overrides` table to enable testing of multi-tenant pricing logic.

###  **What Changed**
- **Created**: `seeds/shared/1754740128395_tenant_pricing_overrides_seed.sql`
- **Added**: 3 tenant-specific pricing overrides demonstrating fee customization
- **Resolves**: Empty table preventing testing of tenant-specific pricing features

###  **Technical Details**
- **Primary Example**: Tenant `550e8400-e29b-41d4-a716-446655440000` overrides `platform_fee_usdc` from default 2.5% to **1.5%**
- **Additional Examples**: XLM fee override (2.0%) and premium tenant (3.0%) for comprehensive testing
- **Dynamic References**: Uses `SELECT` statements to maintain referential integrity with existing pricing rules

###  **Testing Impact**
- Enables validation of multi-tenant pricing logic
- Provides practical examples for development and QA
- Demonstrates fee customization capabilities across different token types

###  **Verification**
- Seed data successfully applied to database
- Tables properly tracked in Hasura GraphQL engine
- Data accessible via GraphQL API for testing

**Closes** #186 