### PR TITLE
fix:Remove unnecessary environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       start_period: 10s
     networks:
       - safetrust-network
+
   graphql-engine:
     image: hasura/graphql-engine:v2.47.0
     ports:
@@ -42,11 +43,12 @@ services:
       start_period: 10s
     networks:
       - safetrust-network
+
   data-connector-agent:
     image: hasura/graphql-data-connector:v2.47.0
     restart: always
     ports:
-      - "8083:8081" # Changed from 8081:8081 to 8083:8081
+      - "8083:8081"
     environment:
       QUARKUS_LOG_LEVEL: ERROR
       QUARKUS_OPENTELEMETRY_ENABLED: "false"
@@ -58,21 +60,7 @@ services:
       start_period: 5s
     networks:
       - safetrust-network
-  redis:
-    image: redis:7-alpine
-    restart: always
-    ports:
-      - "6380:6379"
-    volumes:
-      - redis_data:/data
-    command: redis-server --appendonly yes
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
-    networks:
-      - safetrust-network
+
   console:
     build:
       context: .
@@ -81,7 +69,6 @@ services:
       - "9693:9693"
       - "9695:9695"
     environment:
-      # Fixed the port to match the GraphQL engine's actual port
       HASURA_GRAPHQL_ENDPOINT: http://graphql-engine:8080
       HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
       HASURA_RUN_CONSOLE: "true"
@@ -93,71 +80,8 @@ services:
     networks:
       - safetrust-network
 
-  # --- Webhook Service ---
-  webhook:
-    build:
-      context: ./webhook
-      dockerfile: Dockerfile
-    container_name: safetrust-webhook
-    ports:
-      - "3001:3001"
-    environment:
-      - NODE_ENV=development
-      - WEBHOOK_PORT=3001
-      - HASURA_GRAPHQL_ADMIN_SECRET=${HASURA_GRAPHQL_ADMIN_SECRET}
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=safetrust
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POLYGON_RPC_URL=${POLYGON_RPC_URL}
-      - ETHEREUM_RPC_URL=${ETHEREUM_RPC_URL}
-      - MIN_CONFIRMATIONS=3
-      - ADMIN_PRIVATE_KEY=${ADMIN_PRIVATE_KEY}
-      - BLOCKCHAIN_NETWORK=polygon
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_REGION=${AWS_REGION}
-      - S3_BUCKET=${S3_BUCKET}
-      - FRONTEND_URL=http://localhost:3000
-      - NEXT_PUBLIC_HASURA_GRAPHQL_URL=http://graphql-engine:8080/v1/graphql
-      - SMTP_HOST=smtp.host.com
-      - SMTP_PORT=465
-      - SMTP_SECURE=true
-      - SMTP_USER=your-user
-      - SMTP_PASS=your-password
-      - SMTP_FROM=your-email@example.com
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=safetrust_db
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgrespassword
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - JWT_SECRET=myadminsecretkey
-      - LOG_LEVEL=info
-      - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
-    volumes:
-      - ./webhook:/app
-      - /app/node_modules  
-    depends_on:
-      - postgres
-      - graphql-engine
-      - redis
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-
-    networks:
-      - safetrust-network
-    restart: unless-stopped
-
 volumes:
   db_data:
-  redis_data:
 
 networks:
   safetrust-network:


### PR DESCRIPTION
## ♻️ Simplify docker-compose.yml — Remove unused services and clean up environment variables

### Summary
This PR simplifies the `docker-compose.yml` by removing services and environment variables that are not currently needed, bringing the setup back to a clean and minimal foundation.

---

### Changes

**Removed services:**
- `webhook` — not in use at this stage of development
- `redis` — no longer needed without the webhook service

**Removed environment variables:**
- `POLYGON_RPC_URL` and `ETHEREUM_RPC_URL` — blockchain RPC calls are delegated to TrustlessWork's API
- `ADMIN_PRIVATE_KEY` and `BLOCKCHAIN_NETWORK` — no direct transaction signing in this service
- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET` — S3 not relevant to this service
- Removed duplicate `POSTGRES_*` environment variable declarations in the webhook block
- Removed `redis_data` volume

**Fixes carried over from previous iteration:**
- `data-connector-agent` port corrected to `8083:8081`
- `safetrust-network` now explicitly defined for all services
- `console` service depends on `graphql-engine` with `condition: service_healthy` for more robust startup ordering

---

### Motivation
The docker-compose had accumulated environment variables and services from earlier architectural approaches (direct blockchain interaction, S3 file handling, Redis rate limiting) that are no longer applicable. This cleanup reduces noise, avoids confusion for new contributors, and makes the local dev setup faster and easier to spin up.

---

### Testing
- [ ] `docker compose up` starts all 4 services successfully
- [ ] Hasura console is accessible at `http://localhost:9695`
- [ ] GraphQL engine is healthy at `http://localhost:8080/healthz`
- [ ] PostgreSQL is reachable on port `5433`