### PR TITLE
🛠 Fix CodeRabbit CI Authentication for GitHub Actions

### DIFF
--- a/.github/workflows/coderabbit-review.yml
+++ b/.github/workflows/coderabbit-review.yml
@@ -1,66 +1,22 @@
-name: CodeRabbit AI Review
+name: CodeRabbit Review
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - '**' # Runs on ALL branches
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
-  coderabbit-review:
+  review:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
-    
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: CodeRabbit Review
+        uses: coderabbitai/coderabbit-action@v2
         with:
-          fetch-depth: 0
-      
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-      
-      - name: Install CodeRabbit CLI
-        run: |
-          curl -fsSL https://cli.coderabbit.ai/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-      
-      - name: Authenticate CodeRabbit
-        env:
-          CODERABBIT_TOKEN: ${{ secrets.CODERABBIT_TOKEN }}
-        run: |
-          coderabbit auth login --token $CODERABBIT_TOKEN
-      
-      - name: Run CodeRabbit Review
-        id: review
-        run: |
-          coderabbit review --plain > review_output.txt 2>&1
-          cat review_output.txt
-      
-      - name: Comment Review on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require('fs');
-            const review = fs.readFileSync('review_output.txt', 'utf8');
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## 🐰 CodeRabbit Review\n\n\`\`\`\n${review}\n\`\`\``
-            });
-      
-      - name: Upload Review Artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coderabbit-review
-          path: review_output.txt
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
---
## 📌 Problem

The CI workflow was failing during the `Authenticate CodeRabbit` step with the following error:

<img width="811" height="429" alt="Screenshot from 2026-02-21 22-51-30" src="https://github.com/user-attachments/assets/6dd8f087-bdb9-4a19-b209-c02fe29b07f8" />

```

error: unknown option '--token'
```

The pipeline attempted to authenticate using:

```bash
coderabbit auth login --token $CODERABBIT_TOKEN
```

However, the `coderabbit auth login` command does not support `--token` and is designed for interactive OAuth login (local development), not CI environments.

As a result, the GitHub Action failed with exit code 1.

---

## ✅ Solution

Removed the manual CLI authentication step and replaced it with the official CodeRabbit GitHub Action integration:

```yaml
- name: CodeRabbit Review
  uses: coderabbitai/coderabbit-action@v2
  with:
    github_token: ${{ secrets.GITHUB_TOKEN }}
```

This approach:

* Uses GitHub’s built-in `GITHUB_TOKEN`
* Avoids interactive authentication
* Aligns with CodeRabbit’s recommended CI integration
* Simplifies the workflow
* Prevents future authentication failures

---

## 🔄 Changes Made

* ❌ Removed `coderabbit auth login` step
* ❌ Removed dependency on custom `CODERABBIT_TOKEN`
* ✅ Added official `coderabbitai/coderabbit-action@v2`
* ✅ Configured proper workflow permissions:

  ```yaml
  permissions:
    contents: read
    pull-requests: write
  ```

---

## 🎯 Impact

* CodeRabbit now runs automatically on every pull request
* Stable CI execution (no interactive login required)
* Improved review automation
* Cleaner and more maintainable CI pipeline

---

## 🧬 Why This Matters for SafeTrust

This change strengthens our development workflow by:

* Ensuring consistent automated PR reviews
* Maintaining higher code quality standards
* Supporting scalable open-source contributions
* Moving toward a more production-ready CI/CD pipeline

---