### PR TITLE
fix(hotel_industry): make hotel users migration idempotent

### DIFF
--- a/migrations/hotel_industry/1723171122098_create_hotel_users/up.sql
+++ b/migrations/hotel_industry/1723171122098_create_hotel_users/up.sql
@@ -2,7 +2,7 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Create users table
-CREATE TABLE IF NOT EXISTS users (
+CREATE TABLE IF NOT EXISTS public.users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     email VARCHAR(150) NOT NULL,
     first_name VARCHAR(20),
@@ -13,9 +13,16 @@ CREATE TABLE IF NOT EXISTS users (
     CONSTRAINT users_email_key UNIQUE (email)
 );
 
+-- Ensure timestamp columns exist for pre-existing users table states
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+
+ALTER TABLE public.users
+    ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+
 -- Create indexes
-CREATE INDEX IF NOT EXISTS users_email_idx ON users (email);
-CREATE INDEX IF NOT EXISTS users_created_at_idx ON users (created_at);
+CREATE INDEX IF NOT EXISTS users_email_idx ON public.users (email);
+CREATE INDEX IF NOT EXISTS users_created_at_idx ON public.users (created_at);
 
 -- Create trigger for updating updated_at timestamp
 CREATE OR REPLACE FUNCTION update_updated_at_column()
@@ -26,7 +33,9 @@ BEGIN
 END;
 $$ language 'plpgsql';
 
+DROP TRIGGER IF EXISTS update_users_updated_at ON public.users;
+
 CREATE TRIGGER update_users_updated_at
-    BEFORE UPDATE ON users
+    BEFORE UPDATE ON public.users
     FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column(); 
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
closes #318

## Problem
Applying hotel_industry migration `1723171122098_create_hotel_users` failed with:

`column "created_at" does not exist`

This happened when `public.users` already existed without `created_at` / `updated_at`, while migration used `CREATE TABLE IF NOT EXISTS` and then attempted to create an index on `created_at`.

## What changed
Updated `migrations/hotel_industry/1723171122098_create_hotel_users/up.sql` to be safe for both fresh and pre-existing DB states:

- Use explicit `public.users` table references
- Keep `CREATE TABLE IF NOT EXISTS public.users (...)`
- Add missing timestamp columns idempotently:
  - `ALTER TABLE public.users ADD COLUMN IF NOT EXISTS created_at ...`
  - `ALTER TABLE public.users ADD COLUMN IF NOT EXISTS updated_at ...`
- Create indexes on `public.users`
- Make trigger creation idempotent by dropping existing trigger before creating it

## Why this is safe
- Idempotent on re-runs
- Compatible with existing `down.sql` rollback behavior
- Matches metadata expectations in:
  - `metadata/tenants/hotel_industry/databases/tables/public_users.yaml`
  - expected columns: `id, email, first_name, last_name, phone_number, created_at, updated_at`

## Validation performed
- `hasura migrate apply --database-name hotel_industry ...` ✅
- Re-run same command (idempotency) → `nothing to apply` ✅
- `hasura migrate apply --database-name hotel_industry --down 1 ...` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database schema robustness through explicit schema references and idempotent column management to ensure consistency and reliability across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->