### PR TITLE
fix: make CREATE ROLE statements idempotent in room_types migration

### DIFF
--- a/migrations/hotel_industry/1733171122097_create_room_types/up.sql
+++ b/migrations/hotel_industry/1733171122097_create_room_types/up.sql
@@ -18,9 +18,17 @@ CREATE INDEX idx_room_types_name ON room_types(name);
 CREATE INDEX idx_type_id ON room_types(id);
 
 -- Grant permissions
-CREATE ROLE authenticated;
-CREATE ROLE service_role;
-CREATE ROLE admin;
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+        CREATE ROLE authenticated;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+        CREATE ROLE service_role;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin') THEN
+        CREATE ROLE admin;
+    END IF;
+END $$;
 
 GRANT SELECT ON public.room_types TO authenticated;
 GRANT SELECT ON public.room_types TO service_role;


### PR DESCRIPTION
## Summary

- Wraps the three CREATE ROLE statements (authenticated, service_role, admin) in a DO block with existence checks in migrations/hotel_industry/1733171122097_create_room_types/up.sql
- Migration now runs cleanly on both fresh databases and environments where roles already exist
- All GRANT statements remain unchanged

Closes #320

## Test plan
- Run hasura migrate apply on hotel_industry -- completes with no errors
- Run hasura migrate apply a second time -- no errors (idempotent)
- Verify roles exist: SELECT rolname FROM pg_roles WHERE rolname IN ('authenticated', 'service_role', 'admin');
- Verify grants still apply correctly on public.room_types
- Run hasura migrate apply --down 1 -- cleanly reverses the migration

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database initialization with conditional role creation. The system now checks whether database roles already exist before attempting to create them, preventing errors when migrations are re-executed. This improvement ensures greater deployment reliability and makes the database setup process more robust across different deployment environments and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->