### PR TITLE
fix: correct typo 'Aprroved' to 'Approved' in bid_status_histories seed

### DIFF
--- a/seeds/safetrust/1735509833667_create_bid_status_histories.sql
+++ b/seeds/safetrust/1735509833667_create_bid_status_histories.sql
@@ -13,7 +13,7 @@ VALUES
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 8), 'In_Progress', 'Awaiting approval.', (SELECT id FROM users LIMIT 1 OFFSET 8), NOW() - INTERVAL '9 days'),
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 9), 'Approved', 'Reviewed and approved.', (SELECT id FROM users LIMIT 1 OFFSET 9), NOW() - INTERVAL '6 days'),
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 10), 'Rejected', 'Bid amount exceeded limit.', (SELECT id FROM users LIMIT 1 OFFSET 10), NOW() - INTERVAL '2 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 11), 'Aprroved', 'Bid has been finalized', (SELECT id FROM users LIMIT 1 OFFSET 11), NOW() - INTERVAL '6 days'),
+    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 11), 'Approved', 'Bid has been finalized.', (SELECT id FROM users LIMIT 1 OFFSET 11), NOW() - INTERVAL '6 days'),
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 12), 'Submitted', 'Initial status set.', (SELECT id FROM users LIMIT 1 OFFSET 12), NOW() - INTERVAL '10 days'),
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 13), 'In_Progress', 'Work on the bid has begun.', (SELECT id FROM users LIMIT 1 OFFSET 13), NOW() - INTERVAL '3 days'),
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 14), 'Rejected', 'Insufficient details provided.', (SELECT id FROM users LIMIT 1 OFFSET 14), NOW() - INTERVAL '4 days'),


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

This PR fixes a typo in the bid status histories seed file where `'Aprroved'` (with double 'r') was used instead of the correct `'Approved'` status value. This typo would cause invalid status data to be inserted into the database, leading to inconsistencies in the bid status flow and potential application errors.

## 🌀 Summary of Changes

- **Typo correction**: Changed `'Aprroved'` to `'Approved'` in row at offset 11 (line 16)
- **Consistency improvement**: Added missing period to the note text for consistency with other entries

## 🛠 Testing

### Evidence Before Solution

The seed file contained an invalid status value at offset 11:
```sql
'Aprroved'  ❌  -- Invalid status with double 'r'
```

This value doesn't match any valid status in the application layer (`'Submitted'`, `'Reviewed'`, `'Approved'`, `'In_Progress'`, `'Rejected'`, `'Completed'`), which would cause:
- Database queries filtering by valid statuses to miss this record
- Application logic to reject or fail when processing this status
- Inconsistent data in production

### Evidence After Solution

The seed file now uses the correct status value:
```sql
'Approved'  ✅  -- Valid status, matches application layer
```

All status values in the seed file now align with the valid statuses used throughout the application.

## 📂 Related Issue

This pull request will **close #314** upon merging.

---

### Make sure to follow the Git Guidelines for Atomic Commits and read Contributing Guide
The Pull request needs to have the format mentioned below in the Git Guideline

- [Contributing Guide ](https://github.com/safetrustcr/Frontend/issues/34)
- [Git Guidelines](https://github.com/safetrustcr/Frontend/issues/35)

🎉 Thank you for reviewing this PR! 🎉