### PR TITLE
fix: add TRUNCATE guard to bid_status_histories seed for idempotency

### DIFF
--- a/seeds/safetrust/1735509833667_create_bid_status_histories.sql
+++ b/seeds/safetrust/1735509833667_create_bid_status_histories.sql
@@ -1,5 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
+-- Clear existing seed data (development only)
+TRUNCATE bid_status_histories RESTART IDENTITY CASCADE;
+
 INSERT INTO bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
 VALUES
     (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 0), 'Submitted', 'Bid request has been submitted.', (SELECT id FROM users LIMIT 1 OFFSET 0), NOW()),


### PR DESCRIPTION
## Summary
- Adds `TRUNCATE bid_status_histories RESTART IDENTITY CASCADE;` at the top of the seed file
- Ensures running `hasura seed apply` multiple times always results in exactly 20 rows, no duplicates
- Follows the same pattern already used in `1759099933310_pricing_rules_seed.sql`

## Related Issue
Closes #315

## Test plan
- [ ] Run `hasura seed apply` once → verify `SELECT COUNT(*) FROM bid_status_histories` returns 20
- [ ] Run `hasura seed apply` again → verify count is still 20, not 40



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database seeding process to reset and clear existing data before initialization, ensuring a clean state for development and testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->