### PR TITLE
chore: Remove Redundant Index on `room_types.id`

### DIFF
--- a/migrations/hotel_industry/1733171122097_create_room_types/up.sql
+++ b/migrations/hotel_industry/1733171122097_create_room_types/up.sql
@@ -14,8 +14,6 @@ CREATE TABLE room_types (
 
 -- Index for performance (especially if you'll search by name)
 CREATE INDEX idx_room_types_name ON room_types(name);
--- Create index on type_id
-CREATE INDEX idx_type_id ON room_types(id);
 
 -- Grant permissions
 DO $$ BEGIN


### PR DESCRIPTION
## Description

This PR removes the redundant manual index `idx_type_id` from the `room_types` migration. Since `id` is a `PRIMARY KEY`, PostgreSQL automatically creates a unique index, making the manual one unnecessary. Removing it improves write performance and saves disk space.

## Changes

- Removed `CREATE INDEX idx_type_id ON room_types(id);` from `migrations/hotel_industry/1733171122097_create_room_types/up.sql`

- Verified `down.sql` already includes `DROP INDEX IF EXISTS idx_type_id;` for cleanup if applied previously

## Validation Results
I performed the following tests using a Docker environment (via `docker compose -f docker-compose-test.yml`):

- **Migration Application:** Successfully applied up.sql to a fresh PostgreSQL container

- **Index Verification:** Confirmed that only the expected indexes exist on the `room_types` table
    - `room_types_pkey` (Primary Key index - automatically created)
    - `idx_room_types_name` (Custom index on name column)
    - `idx_type_id` was confirmed to be absent, as intended.

<img width="1066" height="260" alt="image" src="https://github.com/user-attachments/assets/0d493e1f-a9f5-4a83-92af-63d979493f3f" />


## Related Issues
- Closes: #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migration to remove an unused index optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->