### PR TITLE
feat: add POST /api/apartments create listing endpoint

### DIFF
--- a/webhook/src/routes/apartments.js
+++ b/webhook/src/routes/apartments.js
@@ -181,12 +181,14 @@ router.post('/', async (req, res) => {
     petFriendly = false,
     description = '',
   } = req.body || {};
+  const normalizedName = typeof name === 'string' ? name.trim() : '';
+  const normalizedLocation = typeof location === 'string' ? location.trim() : '';
 
   if (!ownerId) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  if (!name || !location || pricePerMonth === undefined || pricePerMonth === null) {
+  if (!normalizedName || !normalizedLocation || pricePerMonth === undefined || pricePerMonth === null) {
     return res.status(400).json({
       error: 'Missing required fields: name, location, pricePerMonth',
     });
@@ -232,7 +234,7 @@ router.post('/', async (req, res) => {
   `;
 
   const payloadAddress = {
-    location,
+    location: normalizedLocation,
     bathrooms: parsedBathrooms,
     promotionPercent,
   };
@@ -240,7 +242,7 @@ router.post('/', async (req, res) => {
   try {
     const result = await db.query(insertSql, [
       ownerId,
-      String(name).trim(),
+      normalizedName,
       String(description ?? ''),
       parsedPrice,
       parsedPrice,

--- a/webhook/src/routes/apartments.js
+++ b/webhook/src/routes/apartments.js
@@ -164,4 +164,96 @@ router.get('/', async (req, res) => {
   }
 });
 
+/**
+ * @route POST /api/apartments
+ * @desc Create apartment listing for authenticated owner
+ * @access Protected
+ */
+router.post('/', async (req, res) => {
+  const ownerId = req.user?.uid;
+  const {
+    name,
+    location,
+    pricePerMonth,
+    promotionPercent = null,
+    rooms = 1,
+    bathrooms = 1,
+    petFriendly = false,
+    description = '',
+  } = req.body || {};
+
+  if (!ownerId) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (!name || !location || pricePerMonth === undefined || pricePerMonth === null) {
+    return res.status(400).json({
+      error: 'Missing required fields: name, location, pricePerMonth',
+    });
+  }
+
+  const parsedPrice = Number(pricePerMonth);
+  if (!Number.isFinite(parsedPrice) || parsedPrice <= 0) {
+    return res.status(400).json({ error: 'Invalid pricePerMonth' });
+  }
+
+  const parsedRooms = Number(rooms);
+  if (!Number.isInteger(parsedRooms) || parsedRooms < 1) {
+    return res.status(400).json({ error: 'Invalid rooms value' });
+  }
+
+  if (promotionPercent !== null) {
+    const promo = Number(promotionPercent);
+    if (!Number.isFinite(promo) || promo < 0 || promo > 100) {
+      return res.status(400).json({ error: 'Invalid promotionPercent' });
+    }
+  }
+
+  const parsedBathrooms = Number(bathrooms);
+  if (!Number.isFinite(parsedBathrooms) || parsedBathrooms < 1) {
+    return res.status(400).json({ error: 'Invalid bathrooms value' });
+  }
+
+  const insertSql = `
+    INSERT INTO public.apartments (
+      owner_id,
+      name,
+      description,
+      price,
+      warranty_deposit,
+      coordinates,
+      address,
+      available_from,
+      bedrooms,
+      pet_friendly
+    )
+    VALUES ($1, $2, $3, $4, $5, point(0, 0), $6::jsonb, NOW(), $7, $8)
+    RETURNING *
+  `;
+
+  const payloadAddress = {
+    location,
+    bathrooms: parsedBathrooms,
+    promotionPercent,
+  };
+
+  try {
+    const result = await db.query(insertSql, [
+      ownerId,
+      String(name).trim(),
+      String(description ?? ''),
+      parsedPrice,
+      parsedPrice,
+      JSON.stringify(payloadAddress),
+      parsedRooms,
+      Boolean(petFriendly),
+    ]);
+
+    return res.status(201).json({ apartment: result.rows[0] });
+  } catch (error) {
+    console.error('[apartments/create] ❌', error.message);
+    return res.status(500).json({ error: 'Failed to create apartment' });
+  }
+});
+
 module.exports = router;

--- a/webhook/src/routes/index.js
+++ b/webhook/src/routes/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { authMiddleware } = require('../middleware/auth.middleware');
+const apartmentRoutes = require('./apartments');
 
 // Dummy handlers for demonstration if real routes don't exist yet
 const placeholder = (name) => (req, res) => res.json({ message: `${name} route`, user: req.user });
@@ -9,7 +10,6 @@ const placeholder = (name) => (req, res) => res.json({ message: `${name} route`,
 // const apartmentRoutes = require('./apartment.routes');
 // const bidRoutes = require('./bid.routes');
 // ...
-const apartmentRoutes = placeholder('Apartments');
 const bidRoutes = placeholder('Bid Requests');
 const escrowRoutes = placeholder('Escrow');
 const userRoutes = placeholder('Users');


### PR DESCRIPTION
## Summary
- add `POST /api/apartments` in `webhook/src/routes/apartments.js`
- validate required fields: `name`, `location`, `pricePerMonth`
- enforce authenticated owner from `req.user.uid`
- map request payload to apartment insert and return created row as `{ apartment }`
- return clear `400` errors for invalid payload values and `500` on DB failure
- wire `routes/index.js` to use the real apartments router (instead of placeholder) so `/api/apartments` handlers are reachable

## Notes
- this repository currently shows only one open issue assigned to `Chucks1093` in this repo (`#342`).

Closes #342


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected endpoint to create apartments with input normalization and validation (name, location, price, rooms, bathrooms, optional promotion), returning appropriate success (201) and error (400/401/500) responses.
* **Chores**
  * Mounted the new apartments route in routing configuration and reverted the bid-requests route back to a placeholder handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->