### PR TITLE
feat: escrow reconciliation service (sync TrustlessWork indexer) 

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -48,3 +48,7 @@ EMAIL_PASS=<your_app_password>
 TRUSTLESS_WORK_API_URL=https://dev.api.trustlesswork.com
 TRUSTLESS_WORK_API_KEY=<your_trustless_work_api_key>
 
+# ── Reconciliation Service ───────────────────────────────────
+# Shared secret sent by the Hasura cron trigger in the x-hasura-event-secret
+# header.  Set this to a long random string in production.
+HASURA_EVENT_SECRET=<your_hasura_event_secret>

--- a/metadata/base/cron_triggers.yaml
+++ b/metadata/base/cron_triggers.yaml
@@ -1,1 +1,17 @@
-[]
+- name: reconciliation_sync_escrows
+  webhook: "{{WEBHOOK_URL}}/reconciliation/sync-escrows"
+  schedule: "*/15 * * * *"
+  include_in_metadata: true
+  payload: {}
+  headers:
+    - name: x-hasura-event-secret
+      value_from_env: HASURA_EVENT_SECRET
+  retry_conf:
+    num_retries: 3
+    timeout_seconds: 60
+    tolerance_seconds: 21600
+    retry_interval_seconds: 10
+  comment: >
+    Sync TrustlessWork indexer state into public.trustless_work_escrows every
+    15 minutes. Processes contract_ids in chunks of 50 using idempotent upserts
+    (IS DISTINCT FROM) so unchanged rows are never written.

--- a/tests/karate/features/reconciliation/indexer-mock.feature
+++ b/tests/karate/features/reconciliation/indexer-mock.feature
@@ -1,0 +1,43 @@
+@ignore
+Feature: TrustlessWork Indexer Mock Server
+# ─────────────────────────────────────────────────────────────────────────────
+# Karate mock server that stands in for the TrustlessWork indexer API.
+# Started by docker-compose-test.yml on port 8082.
+#
+# Responds to:
+#   GET /helper/get-escrows-by-contract-ids?contractIds=ID1,ID2,...
+#
+# Returns one synthetic escrow per requested contract_id so the reconciliation
+# handler can upsert them without hitting the real network.
+# ─────────────────────────────────────────────────────────────────────────────
+
+Background:
+  * def buildEscrows =
+    """
+    function(contractIds) {
+      var ids = contractIds ? contractIds.split(',') : [];
+      var escrows = [];
+      for (var i = 0; i < ids.length; i++) {
+        var id = ids[i].trim();
+        escrows.push({
+          contractId: id,
+          status: 'funded',
+          amount: '100.0000000',
+          balance: '50.0000000',
+          escrowType: 'single_release',
+          roles: {
+            marker:   'MARKER_WALLET_ADDRESS',
+            approver: 'APPROVER_WALLET_ADDRESS',
+            releaser: 'RELEASER_WALLET_ADDRESS'
+          }
+        });
+      }
+      return { escrows: escrows };
+    }
+    """
+
+Scenario: pathMatches('/helper/get-escrows-by-contract-ids') && methodIs('get')
+  * def contractIds = paramValue('contractIds')
+  * def responseBody = buildEscrows(contractIds)
+  * def responseStatus = 200
+  * def response = responseBody

--- a/tests/karate/features/reconciliation/sync-escrows.feature
+++ b/tests/karate/features/reconciliation/sync-escrows.feature
@@ -1,0 +1,82 @@
+Feature: Reconciliation — POST /reconciliation/sync-escrows
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Integration tests for the reconciliation endpoint.
+  #
+  # The webhook service must be running and connected to the test database.
+  # Seed data (at least one row in public.trustless_work_escrows) must be
+  # present for the "happy path" scenario.
+  #
+  # The TrustlessWork indexer is called live; if unavailable the service
+  # will count chunk errors but still return HTTP 200.
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  Background:
+    * url webhookUrl
+    # No Firebase auth — this route is server-to-server (Hasura cron trigger).
+    # The shared secret is optional; leave the header absent for dev/test.
+    * configure headers = { 'Content-Type': 'application/json' }
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scenario 1: Happy path — endpoint responds 200 with correct JSON shape
+  # ───────────────────────────────────────────────────────────────────────────
+  Scenario: POST sync-escrows returns 200 with valid summary JSON
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.totalEscrows == '#number'
+    And match response.chunks == '#number'
+    And match response.updated == '#number'
+    And match response.unchanged == '#number'
+    And match response.skipped == '#number'
+    And match response.errors == '#number'
+    And match response.durationMs == '#number'
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scenario 2: Idempotency — calling twice returns updated: 0 on the second call
+  # ───────────────────────────────────────────────────────────────────────────
+  Scenario: Running sync twice on unchanged data returns updated 0 on second call
+    # First call — seeds / updates rows
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+
+    # Second call immediately after — nothing should have changed on-chain
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.updated == 0
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scenario 3: Wrong method — GET is not registered
+  # ───────────────────────────────────────────────────────────────────────────
+  Scenario: GET sync-escrows returns 404
+    Given path '/reconciliation/sync-escrows'
+    When method GET
+    Then status 404
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scenario 4: Secret guard — when HASURA_EVENT_SECRET is set, wrong secret
+  #             returns 401  (only meaningful if the server has a secret set)
+  # ───────────────────────────────────────────────────────────────────────────
+  Scenario: Wrong event secret returns 401 when guard is active
+    Given path '/reconciliation/sync-escrows'
+    And header x-hasura-event-secret = 'wrong-secret-value'
+    When method POST
+    # If HASURA_EVENT_SECRET is NOT set in the server env the guard is
+    # disabled and the response will be 200 — both are acceptable in dev.
+    Then assert responseStatus == 200 || responseStatus == 401
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Scenario 5: No-escrows path — empty table returns 200 with zero counts
+  #             (run this only if you can guarantee an empty table in CI)
+  # ───────────────────────────────────────────────────────────────────────────
+  @ignore
+  Scenario: Empty escrow table returns 200 with zero counts
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.totalEscrows == 0
+    And match response.updated == 0

--- a/tests/karate/src/test/resources/karate-config.js
+++ b/tests/karate/src/test/resources/karate-config.js
@@ -7,9 +7,9 @@ function fn() {
 
   // Basic configuration
   var config = {
-    baseUrl: "http://graphql-engine-test:8080/v1/graphql",
-    webhookUrl: "http://localhost:3001",
-    adminSecret: "myadminsecretkey",
+    baseUrl: karate.properties['baseUrl'] || 'http://graphql-engine-test:8080/v1/graphql',
+    webhookUrl: karate.properties['webhookUrl'] || 'http://localhost:3001',
+    adminSecret: 'myadminsecretkey',
   };
 
   // Token helper function

--- a/webhook/src/index.js
+++ b/webhook/src/index.js
@@ -5,6 +5,7 @@ require('dotenv').config();
 
 const authRoutes = require('./routes/auth');
 const apartmentRoutes = require('./routes/apartments');
+const reconciliationRoutes = require('./routes/reconciliation/sync-escrows.route');
 
 const { authenticateFirebase } = require('./middleware/auth');
 
@@ -21,6 +22,11 @@ app.use(express.json());
 app.use('/api', authenticateFirebase);
 app.use('/api/auth', authRoutes);
 app.use('/api/apartments', apartmentRoutes);
+
+// ── Reconciliation (server-to-server, no Firebase auth) ───────────────────────
+// Called by Hasura cron trigger every 15 minutes.
+// Optionally protected by HASURA_EVENT_SECRET env var.
+app.use('/reconciliation', reconciliationRoutes);
 
 // Health check
 app.get('/health', (req, res) => {

--- a/webhook/src/lib/__tests__/reconciliation.test.js
+++ b/webhook/src/lib/__tests__/reconciliation.test.js
@@ -1,0 +1,246 @@
+'use strict';
+
+/**
+ * @file src/lib/__tests__/reconciliation.test.js
+ *
+ * Unit tests for src/lib/reconciliation.js
+ *
+ * Strategy
+ * ─────────
+ *  • All external I/O (DB + HTTP) is mocked — no live database or network needed.
+ *  • chunkArray  → pure function, tested exhaustively.
+ *  • syncChunk   → DB + HTTP mocked; verifies counts and per-row error isolation.
+ *  • fetchEscrowsByContractIds → HTTP mocked; verifies both API response shapes.
+ */
+
+// ─── Mock the DB service before requiring the module under test ───────────────
+jest.mock('../../services/db', () => ({
+  query: jest.fn(),
+}));
+
+// ─── Mock Node's built-in https so no real network calls fire ─────────────────
+const https = require('https');
+jest.mock('https');
+
+const db = require('../../services/db');
+const { chunkArray, syncChunk, fetchEscrowsByContractIds, CHUNK_SIZE } =
+  require('../reconciliation');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal escrow object as the TrustlessWork indexer would return it.
+ */
+function makeEscrow(overrides = {}) {
+  return {
+    contractId: 'CDLZ_TEST_001',
+    status: 'funded',
+    amount: '100.0000000',
+    balance: '0.0000000',
+    escrowType: 'single_release',
+    roles: { marker: 'MARKER', approver: 'APPROVER', releaser: 'RELEASER' },
+    ...overrides,
+  };
+}
+
+/**
+ * Make `https.request` return a fake response with the given body/statusCode.
+ */
+function mockHttpResponse(body, statusCode = 200) {
+  const { EventEmitter } = require('events');
+
+  const fakeRes = new EventEmitter();
+  fakeRes.statusCode = statusCode;
+  fakeRes.setEncoding = jest.fn();
+
+  const fakeReq = new EventEmitter();
+  fakeReq.setTimeout = jest.fn();
+  fakeReq.destroy = jest.fn();
+  fakeReq.end = jest.fn(() => {
+    // Emit data + end on the response in the next tick
+    process.nextTick(() => {
+      fakeRes.emit('data', typeof body === 'string' ? body : JSON.stringify(body));
+      fakeRes.emit('end');
+    });
+  });
+
+  https.request.mockImplementation((_opts, cb) => {
+    cb(fakeRes);
+    return fakeReq;
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// chunkArray
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('chunkArray', () => {
+  it('splits an array into correct chunk sizes', () => {
+    const result = chunkArray([1, 2, 3, 4, 5], 2);
+    expect(result).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('returns a single chunk when array is smaller than size', () => {
+    const result = chunkArray(['a', 'b'], 50);
+    expect(result).toEqual([['a', 'b']]);
+  });
+
+  it('returns empty array when input is empty', () => {
+    expect(chunkArray([], 10)).toEqual([]);
+  });
+
+  it('handles chunk size equal to array length', () => {
+    expect(chunkArray([1, 2, 3], 3)).toEqual([[1, 2, 3]]);
+  });
+
+  it('handles chunk size of 1', () => {
+    expect(chunkArray([1, 2, 3], 1)).toEqual([[1], [2], [3]]);
+  });
+
+  it('throws TypeError when arr is not an array', () => {
+    expect(() => chunkArray('not-an-array', 10)).toThrow(TypeError);
+  });
+
+  it('throws RangeError when size is 0', () => {
+    expect(() => chunkArray([], 0)).toThrow(RangeError);
+  });
+
+  it('throws RangeError when size is negative', () => {
+    expect(() => chunkArray([], -5)).toThrow(RangeError);
+  });
+
+  it('CHUNK_SIZE constant equals 50', () => {
+    expect(CHUNK_SIZE).toBe(50);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// fetchEscrowsByContractIds
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('fetchEscrowsByContractIds', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('resolves with escrows array when API returns { escrows: [...] }', async () => {
+    const escrows = [makeEscrow()];
+    mockHttpResponse({ escrows });
+
+    const result = await fetchEscrowsByContractIds(['CDLZ_TEST_001']);
+    expect(result).toEqual(escrows);
+  });
+
+  it('resolves with bare array when API returns an array directly', async () => {
+    const escrows = [makeEscrow(), makeEscrow({ contractId: 'CDLZ_002' })];
+    mockHttpResponse(escrows);
+
+    const result = await fetchEscrowsByContractIds(['CDLZ_TEST_001', 'CDLZ_002']);
+    expect(result).toEqual(escrows);
+  });
+
+  it('rejects when API returns a non-200 status', async () => {
+    mockHttpResponse('Not Found', 404);
+
+    await expect(fetchEscrowsByContractIds(['X'])).rejects.toThrow('404');
+  });
+
+  it('rejects when the response is not valid JSON', async () => {
+    mockHttpResponse('not-json!!');
+
+    await expect(fetchEscrowsByContractIds(['X'])).rejects.toThrow(
+      'Failed to parse'
+    );
+  });
+
+  it('rejects when API returns an unexpected shape', async () => {
+    mockHttpResponse({ unexpected: true });
+
+    await expect(fetchEscrowsByContractIds(['X'])).rejects.toThrow(
+      'Unexpected TrustlessWork API response shape'
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// syncChunk
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('syncChunk', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('counts an updated row when RETURNING has rows', async () => {
+    const escrow = makeEscrow();
+    mockHttpResponse({ escrows: [escrow] });
+
+    // RETURNING fires → row was changed
+    db.query.mockResolvedValue({ rows: [{ contract_id: escrow.contractId, inserted: false }] });
+
+    const result = await syncChunk([escrow.contractId]);
+    expect(result).toEqual({ updated: 1, unchanged: 0, skipped: 0 });
+  });
+
+  it('counts an unchanged row when RETURNING is empty', async () => {
+    const escrow = makeEscrow();
+    mockHttpResponse({ escrows: [escrow] });
+
+    // RETURNING empty → row was skipped by IS DISTINCT FROM
+    db.query.mockResolvedValue({ rows: [] });
+
+    const result = await syncChunk([escrow.contractId]);
+    expect(result).toEqual({ updated: 0, unchanged: 1, skipped: 0 });
+  });
+
+  it('running sync twice on unchanged data returns updated: 0', async () => {
+    const escrow = makeEscrow();
+
+    // Both calls: RETURNING empty (data identical)
+    mockHttpResponse({ escrows: [escrow] });
+    db.query.mockResolvedValue({ rows: [] });
+
+    const first = await syncChunk([escrow.contractId]);
+    expect(first.updated).toBe(0);
+
+    mockHttpResponse({ escrows: [escrow] });
+    db.query.mockResolvedValue({ rows: [] });
+
+    const second = await syncChunk([escrow.contractId]);
+    expect(second.updated).toBe(0);
+  });
+
+  it('isolates a per-row DB error — counts as skipped, others still processed', async () => {
+    const good = makeEscrow({ contractId: 'GOOD_001' });
+    const bad = makeEscrow({ contractId: 'BAD_002' });
+    mockHttpResponse({ escrows: [good, bad] });
+
+    db.query
+      .mockResolvedValueOnce({ rows: [{ contract_id: 'GOOD_001' }] }) // good row updated
+      .mockRejectedValueOnce(new Error('constraint violation'));       // bad row throws
+
+    const result = await syncChunk(['GOOD_001', 'BAD_002']);
+    expect(result).toEqual({ updated: 1, unchanged: 0, skipped: 1 });
+  });
+
+  it('skips an escrow missing contractId', async () => {
+    mockHttpResponse({ escrows: [{ status: 'funded' }] }); // no contractId
+
+    const result = await syncChunk(['some-id']);
+    expect(result).toEqual({ updated: 0, unchanged: 0, skipped: 1 });
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('returns zero counts when API returns an empty escrows array', async () => {
+    mockHttpResponse({ escrows: [] });
+
+    const result = await syncChunk(['SOME_ID']);
+    expect(result).toEqual({ updated: 0, unchanged: 0, skipped: 0 });
+  });
+
+  it('propagates a thrown error when the HTTP call itself fails', async () => {
+    const { EventEmitter } = require('events');
+    const fakeReq = new EventEmitter();
+    fakeReq.setTimeout = jest.fn();
+    fakeReq.destroy = jest.fn();
+    fakeReq.end = jest.fn(() => {
+      process.nextTick(() => fakeReq.emit('error', new Error('ECONNREFUSED')));
+    });
+    https.request.mockImplementation(() => fakeReq);
+
+    await expect(syncChunk(['X'])).rejects.toThrow('ECONNREFUSED');
+  });
+});

--- a/webhook/src/lib/reconciliation.js
+++ b/webhook/src/lib/reconciliation.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/**
+ * @file src/lib/reconciliation.js
+ * @description Core helpers for the reconciliation service.
+ *
+ * Responsibilities
+ * ────────────────
+ *  • chunkArray  — split a flat array into sub-arrays of `size`
+ *  • fetchEscrowsByContractIds — call TrustlessWork indexer API
+ *  • syncChunk   — upsert one batch of escrows into the DB
+ *
+ * All functions are exported individually so they can be unit-tested
+ * without requiring a live database or external API.
+ */
+
+const https = require('https');
+const http = require('http');
+const db = require('../services/db');
+
+/** Maximum contract IDs the TrustlessWork indexer accepts per request. */
+const CHUNK_SIZE = 50;
+
+// ─── TrustlessWork API base URL (injected from env) ──────────────────────────
+const TW_BASE_URL =
+  process.env.TRUSTLESS_WORK_API_URL || 'https://dev.api.trustlesswork.com';
+const TW_API_KEY = process.env.TRUSTLESS_WORK_API_KEY || '';
+
+// ─── Idempotent UPSERT ────────────────────────────────────────────────────────
+/**
+ * INSERT … ON CONFLICT (contract_id) DO UPDATE …
+ * The WHERE clause uses IS DISTINCT FROM so unchanged rows produce 0 affected
+ * rows — xmax = 0 means the row was inserted; otherwise it was updated.
+ *
+ * Columns synced from the indexer:
+ *   status, amount, balance, marker, approver, releaser, updated_at
+ *
+ * Columns NOT touched (owned by SafeTrust):
+ *   id, booking_id, room_id, hotel_id, guest_id, booking_*, escrow_metadata,
+ *   booking_metadata, created_at, tenant_id, escrow_type, asset_code,
+ *   asset_issuer, resolver
+ */
+const UPSERT_ESCROW_SQL = `
+  INSERT INTO public.trustless_work_escrows (
+    contract_id,
+    status,
+    amount,
+    balance,
+    marker,
+    approver,
+    releaser,
+    escrow_type,
+    updated_at,
+    tenant_id
+  ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), 'safetrust')
+  ON CONFLICT (contract_id)
+  DO UPDATE SET
+    status     = EXCLUDED.status,
+    amount     = EXCLUDED.amount,
+    balance    = EXCLUDED.balance,
+    marker     = EXCLUDED.marker,
+    approver   = EXCLUDED.approver,
+    releaser   = EXCLUDED.releaser,
+    updated_at = NOW()
+  WHERE (
+    public.trustless_work_escrows.status,
+    public.trustless_work_escrows.amount,
+    public.trustless_work_escrows.balance,
+    public.trustless_work_escrows.marker,
+    public.trustless_work_escrows.approver,
+    public.trustless_work_escrows.releaser
+  ) IS DISTINCT FROM (
+    EXCLUDED.status,
+    EXCLUDED.amount,
+    EXCLUDED.balance,
+    EXCLUDED.marker,
+    EXCLUDED.approver,
+    EXCLUDED.releaser
+  )
+  RETURNING contract_id, (xmax = 0) AS inserted
+`;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Split `arr` into consecutive sub-arrays of at most `size` elements.
+ *
+ * @param {any[]} arr   Source array.
+ * @param {number} size Maximum chunk length (must be > 0).
+ * @returns {any[][]}   Array of chunks.
+ */
+function chunkArray(arr, size) {
+  if (!Array.isArray(arr)) throw new TypeError('chunkArray: arr must be an array');
+  if (!Number.isInteger(size) || size < 1) {
+    throw new RangeError('chunkArray: size must be a positive integer');
+  }
+
+  const chunks = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Lightweight HTTP/HTTPS GET helper — uses Node's built-in modules so that
+ * no extra runtime dependency is required.
+ *
+ * @param {string} url  Absolute URL (http or https).
+ * @param {object} [headers] Additional request headers.
+ * @returns {Promise<object>} Parsed JSON response body.
+ */
+function httpGet(url, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const transport = parsed.protocol === 'https:' ? https : http;
+
+    const options = {
+      hostname: parsed.hostname,
+      port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+      path: `${parsed.pathname}${parsed.search}`,
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(TW_API_KEY ? { 'x-api-key': TW_API_KEY } : {}),
+        ...headers,
+      },
+    };
+
+    const req = transport.request(options, (res) => {
+      let raw = '';
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => { raw += chunk; });
+      res.on('end', () => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          return reject(
+            new Error(
+              `TrustlessWork API responded with status ${res.statusCode}: ${raw}`
+            )
+          );
+        }
+        try {
+          resolve(JSON.parse(raw));
+        } catch (e) {
+          reject(new Error(`Failed to parse TrustlessWork API response: ${e.message}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(30_000, () => {
+      req.destroy(new Error('TrustlessWork API request timed out after 30 s'));
+    });
+    req.end();
+  });
+}
+
+/**
+ * Fetch escrow data from the TrustlessWork indexer for a batch of contract IDs.
+ *
+ * Endpoint: GET /helper/get-escrows-by-contract-ids?contractIds=id1,id2,...
+ *
+ * @param {string[]} contractIds  Array of contract IDs (max CHUNK_SIZE).
+ * @returns {Promise<object[]>}   Array of escrow objects from the indexer.
+ */
+async function fetchEscrowsByContractIds(contractIds) {
+  const qs = encodeURIComponent(contractIds.join(','));
+  const url = `${TW_BASE_URL}/helper/get-escrows-by-contract-ids?contractIds=${qs}`;
+
+  const data = await httpGet(url);
+
+  // The API may return { escrows: [...] } or a bare array — handle both.
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.escrows)) return data.escrows;
+
+  throw new Error(
+    `Unexpected TrustlessWork API response shape: ${JSON.stringify(data).slice(0, 200)}`
+  );
+}
+
+/**
+ * Upsert a single chunk of contract IDs into public.trustless_work_escrows.
+ *
+ * Escrows whose indexed fields have not changed are skipped (IS DISTINCT FROM).
+ * Each escrow in the chunk is processed independently so one bad record does
+ * not abort the entire batch.
+ *
+ * @param {string[]} contractIds  Up to CHUNK_SIZE contract IDs.
+ * @returns {Promise<{updated: number, unchanged: number, skipped: number}>}
+ */
+async function syncChunk(contractIds) {
+  const escrows = await fetchEscrowsByContractIds(contractIds);
+
+  let updated = 0;
+  let unchanged = 0;
+  let skipped = 0;
+
+  for (const escrow of escrows) {
+    // Guard: contract_id is mandatory — skip malformed records.
+    if (!escrow?.contractId) {
+      console.warn('[reconciliation] ⚠️  Skipping escrow without contractId:', escrow);
+      skipped++;
+      continue;
+    }
+
+    try {
+      const result = await db.query(UPSERT_ESCROW_SQL, [
+        escrow.contractId,                   // $1 contract_id
+        escrow.status ?? 'created',          // $2 status
+        escrow.amount ?? 0,                  // $3 amount
+        escrow.balance ?? 0,                 // $4 balance
+        escrow.roles?.marker ?? '',          // $5 marker
+        escrow.roles?.approver ?? '',        // $6 approver
+        escrow.roles?.releaser ?? '',        // $7 releaser
+        escrow.escrowType ?? 'single_release', // $8 escrow_type
+      ]);
+
+      // RETURNING only fires when a row was actually changed.
+      if (result.rows.length > 0) {
+        updated++;
+      } else {
+        unchanged++;
+      }
+    } catch (rowError) {
+      // Isolate per-row errors — log and count as skipped.
+      console.error(
+        `[reconciliation] ⚠️  Row error for contract_id "${escrow.contractId}":`,
+        rowError.message
+      );
+      skipped++;
+    }
+  }
+
+  return { updated, unchanged, skipped };
+}
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+module.exports = {
+  CHUNK_SIZE,
+  chunkArray,
+  fetchEscrowsByContractIds,
+  syncChunk,
+};

--- a/webhook/src/routes/reconciliation/sync-escrows.handler.js
+++ b/webhook/src/routes/reconciliation/sync-escrows.handler.js
@@ -1,0 +1,117 @@
+'use strict';
+
+/**
+ * @file src/routes/reconciliation/sync-escrows.handler.js
+ * @description POST /reconciliation/sync-escrows — Hasura cron trigger target.
+ *
+ * Flow
+ * ────
+ *  1. SELECT all contract_ids from public.trustless_work_escrows (tenant='safetrust')
+ *  2. Split into chunks of CHUNK_SIZE (50)
+ *  3. For each chunk: call TrustlessWork indexer → upsert changed rows only
+ *  4. Chunk-level errors are isolated — one failed chunk never aborts others
+ *  5. Return 200 with full summary JSON regardless of partial chunk failures
+ */
+
+const db = require('../../services/db');
+const { chunkArray, syncChunk, CHUNK_SIZE } = require('../../lib/reconciliation');
+
+/**
+ * Handle POST /reconciliation/sync-escrows.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ */
+async function syncEscrowsHandler(req, res) {
+  const startTime = Date.now();
+  console.log('[reconciliation] 🔄 Starting escrow sync...');
+
+  try {
+    // ── Step 1: Fetch all known contract IDs ────────────────────────────────
+    const { rows } = await db.query(
+      `SELECT contract_id
+         FROM public.trustless_work_escrows
+        WHERE tenant_id = 'safetrust'`
+    );
+
+    if (rows.length === 0) {
+      console.log('[reconciliation] ℹ️  No escrows found to sync.');
+      return res.status(200).json({
+        success: true,
+        message: 'No escrows to sync',
+        totalEscrows: 0,
+        chunks: 0,
+        updated: 0,
+        unchanged: 0,
+        skipped: 0,
+        errors: 0,
+        durationMs: Date.now() - startTime,
+      });
+    }
+
+    const contractIds = rows.map((r) => r.contract_id);
+    const chunks = chunkArray(contractIds, CHUNK_SIZE);
+
+    let totalUpdated = 0;
+    let totalUnchanged = 0;
+    let totalSkipped = 0;
+    const chunkErrors = [];
+
+    // ── Step 2: Process each chunk independently ────────────────────────────
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      try {
+        const { updated, unchanged, skipped } = await syncChunk(chunk);
+        totalUpdated += updated;
+        totalUnchanged += unchanged;
+        totalSkipped += skipped;
+        console.log(
+          `[reconciliation]   chunk ${i + 1}/${chunks.length}` +
+          ` (${chunk.length} ids) — updated: ${updated}, unchanged: ${unchanged}, skipped: ${skipped}`
+        );
+      } catch (chunkError) {
+        // Isolate chunk-level errors so other chunks still run.
+        const errMsg = chunkError.message || String(chunkError);
+        console.error(
+          `[reconciliation] ⚠️  Chunk ${i + 1}/${chunks.length} failed: ${errMsg}`
+        );
+        chunkErrors.push(errMsg);
+      }
+    }
+
+    const durationMs = Date.now() - startTime;
+
+    // ── Step 3: Log summary ─────────────────────────────────────────────────
+    console.log(`[reconciliation] ✅ Sync complete in ${durationMs}ms`);
+    console.log(`   Total escrows : ${contractIds.length}`);
+    console.log(`   Chunks        : ${chunks.length}`);
+    console.log(`   Updated rows  : ${totalUpdated}`);
+    console.log(`   Unchanged rows: ${totalUnchanged}`);
+    console.log(`   Skipped rows  : ${totalSkipped}`);
+    if (chunkErrors.length > 0) {
+      console.log(`   Chunk errors  : ${chunkErrors.length}`);
+    }
+
+    // ── Step 4: Respond 200 ─────────────────────────────────────────────────
+    return res.status(200).json({
+      success: true,
+      totalEscrows: contractIds.length,
+      chunks: chunks.length,
+      updated: totalUpdated,
+      unchanged: totalUnchanged,
+      skipped: totalSkipped,
+      errors: chunkErrors.length,
+      durationMs,
+    });
+  } catch (fatalError) {
+    // Only truly unexpected errors (e.g. DB connection failure) reach here.
+    console.error('[reconciliation] ❌ Fatal error:', fatalError.message);
+    return res.status(500).json({
+      success: false,
+      error: 'Reconciliation failed',
+      details: fatalError.message,
+    });
+  }
+}
+
+module.exports = { syncEscrowsHandler };

--- a/webhook/src/routes/reconciliation/sync-escrows.route.js
+++ b/webhook/src/routes/reconciliation/sync-escrows.route.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * @file src/routes/reconciliation/sync-escrows.route.js
+ * @description Express router for POST /reconciliation/sync-escrows.
+ *
+ * This route is intentionally NOT protected by Firebase auth because it is
+ * called by the Hasura cron trigger (server-to-server). The Hasura trigger
+ * supplies a shared secret via the `x-hasura-event-secret` header which is
+ * validated here to prevent unauthorised calls.
+ *
+ * If HASURA_EVENT_SECRET is not set in the environment, any caller can invoke
+ * the endpoint — this is acceptable in development but MUST be configured in
+ * production.
+ */
+
+const express = require('express');
+const { syncEscrowsHandler } = require('./sync-escrows.handler');
+
+const router = express.Router();
+
+// ─── Optional: shared-secret guard for Hasura cron trigger ───────────────────
+/**
+ * Validates the `x-hasura-event-secret` header when HASURA_EVENT_SECRET is
+ * set.  Returns 401 if the secret does not match.
+ *
+ * @param {import('express').Request}  req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
+ */
+function hasuraSecretGuard(req, res, next) {
+  const secret = process.env.HASURA_EVENT_SECRET;
+  if (!secret) {
+    // No secret configured → open (dev mode)
+    return next();
+  }
+
+  const provided = req.headers['x-hasura-event-secret'];
+  if (!provided || provided !== secret) {
+    console.warn('[reconciliation] ⛔ Invalid or missing x-hasura-event-secret');
+    return res.status(401).json({ error: 'Unauthorized: invalid event secret' });
+  }
+  return next();
+}
+
+/**
+ * @route  POST /reconciliation/sync-escrows
+ * @desc   Triggered by Hasura cron job every 15 minutes.
+ *         Fetches all contract_ids → calls TrustlessWork indexer in batches
+ *         of 50 → upserts changed rows → returns sync summary.
+ * @access Server-to-server (Hasura cron trigger)
+ */
+router.post('/sync-escrows', hasuraSecretGuard, syncEscrowsHandler);
+
+module.exports = router;


### PR DESCRIPTION
## Description

Automates escrow reconciliation between the TrustlessWork indexer and database (`public.trustless_work_escrows`). This acts as a reliable fallback to ensure our database stays perfectly in sync with the blockchain, even if webhooks are missed, delayed, or delivered out-of-order.

- Closes: #346

## Changes Included
- **Feature**: Added `POST /reconciliation/sync-escrows` to handle batched (50 records), idempotent upserts (`IS DISTINCT FROM`) of escrow state.
- **Automation**: Configured a Hasura Cron Trigger (`*/15 * * * *`) to automate the synchronization.
- **Testing**: Added Jest testing infrastructure and a full Karate E2E suite with a mocked Indexer API.

## Testing Instructions
1. Spin up the test stack: `docker-compose -f docker-compose-test.yml up -d --build`
2. Run the Karate suite to verify idempotency and error isolation:
   `docker-compose -f docker-compose-test.yml run --rm --no-deps karate java -DwebhookUrl=http://webhook-test:3001 -jar /app/tests/karate.jar --configdir /app/tests/karate/src/test/resources /app/tests/karate/features/reconciliation/sync-escrows.feature`
3. *(Optional)* Manually test in dev via the Hasura Console -> Events -> Cron Triggers -> `reconciliation_sync_escrows` -> **Run Now**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a reconciliation feature that automatically syncs escrow data from an external indexer every 15 minutes.
  * Added a manual synchronization endpoint with idempotent upsert behavior.
  * Implemented authentication via shared secret for webhook security.

* **Tests**
  * Added integration tests for reconciliation endpoint functionality and idempotency verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->