### PR TITLE
fix: persist TrustlessWork status changes into trustless_work_escrows

### DIFF
--- a/webhook/src/routes/escrow.js
+++ b/webhook/src/routes/escrow.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../services/db');
+
+/**
+ * POST /webhooks/escrow_status_update
+ *
+ * Receives TrustlessWork escrow status change events and updates
+ * the trustless_work_escrows table. Always returns 200 to prevent
+ * TrustlessWork from retrying indefinitely.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+router.post('/escrow_status_update', async (req, res) => {
+  const { event } = req.body;
+  const newData = event?.data?.new;
+
+  if (!newData?.contract_id) {
+    console.warn('[escrow_status_update] Missing contract_id in payload');
+    return res.status(200).json({ message: 'Ignored — missing contract_id' });
+  }
+
+  const { contract_id, status, amount, balance } = newData;
+
+  try {
+    const result = await pool.query(
+      `UPDATE public.trustless_work_escrows
+         SET status     = $1,
+             amount     = $2,
+             balance    = $3,
+             updated_at = NOW()
+       WHERE contract_id = $4
+       RETURNING contract_id`,
+      [status, amount, balance, contract_id]
+    );
+
+    if (result.rows.length === 0) {
+      console.warn(`[escrow_status_update] contract_id=${contract_id} not found`);
+    } else {
+      console.log(`[escrow_status_update] contract_id=${contract_id} → ${status}`);
+    }
+
+    return res.status(200).json({ message: 'Escrow status updated' });
+  } catch (error) {
+    console.error('[escrow_status_update]', error.message);
+    return res.status(200).json({ message: 'Webhook received, DB update failed' });
+  }
+});
+
+module.exports = router;

--- a/webhook/src/routes/index.js
+++ b/webhook/src/routes/index.js
@@ -2,24 +2,21 @@ const express = require('express')
 const router = express.Router()
 
 /**
- * Root router: health, then Firebase-protected `/api/*` routes.
+ * Root router: health, webhooks, then Firebase-protected `/api/*` routes.
  */
 const { authenticateFirebase } = require('../middleware/auth')
 
 const authRoutes = require('./auth')
 const apartmentRoutes = require('./apartments')
 const bidRequestRoutes = require('./bid-requests')
-// In a real app, these would be imported from separate files:
-// const apartmentRoutes = require('./apartment.routes');
-// ...
-const bidRoutes = placeholder('Bid Requests');
-const escrowRoutes = placeholder('Escrow');
-const userRoutes = placeholder('Users');
-const healthRoute = (req, res) => res.status(200).send('OK');
-const webhookRoutes = (req, res) => res.status(200).json({ status: 'received' });
+const escrowRoutes = require('./escrow')
 
 router.get('/health', (req, res) => res.status(200).send('OK'))
 
+// Webhook routes — no auth required (called by external services)
+router.use('/webhooks', escrowRoutes)
+
+// API routes — Firebase auth required
 router.use('/api', authenticateFirebase)
 router.use('/api/auth', authRoutes)
 router.use('/api/apartments', apartmentRoutes)


### PR DESCRIPTION
Closes #357 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook endpoint for escrow status updates. The system now receives and processes escrow status-change events, automatically updating corresponding records with the latest status and balance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->