### PR TITLE
fix: sync public_users.yaml with dApp-SafeTrust canonical metadata

### DIFF
--- a/metadata/tenants/safetrust/databases/tables/public_users.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_users.yaml
@@ -10,82 +10,62 @@ array_relationships:
           name: user_wallets
           schema: public
 select_permissions:
-  - role: anonymous
-    permission:
-      columns: []
-      filter: {}
-    comment: "Anonymous users cannot view any user data"
-  - role: user
+  - role: tenant
     permission:
       columns:
         - id
+        - firebase_uid
         - email
+        - first_name
+        - last_name
+        - phone_number
+        - country_code
+        - location
         - last_seen
       filter:
-        # Row-level security: users can only see their own profile
         id:
           _eq: X-Hasura-User-Id
-      comment: "Users can only see their own profile"
-  - role: admin
+  - role: landlord
     permission:
       columns:
         - id
+        - firebase_uid
         - email
+        - first_name
+        - last_name
+        - phone_number
+        - country_code
+        - location
         - last_seen
       filter:
-        # Admins can view all users in their tenant
-        id:
-          _neq: ""
-      comment: "Admins can view all users in their tenant"
-insert_permissions:
-  - role: user
-    permission:
-      check:
-        # Row-level security: users can only create records for themselves
         id:
           _eq: X-Hasura-User-Id
-      columns:
-        - id
-        - email
-      comment: "Users can only create records for themselves"
-  - role: admin
-    permission:
-      check:
-        id:
-          _neq: ""
-      columns:
-        - id
-        - email
-      comment: "Admins can create user records in their tenant"
 update_permissions:
-  - role: user
+  - role: tenant
     permission:
       columns:
-        - last_seen
+        - first_name
+        - last_name
+        - phone_number
+        - country_code
+        - location
       filter:
-        # Row-level security: users can only update their own profile
         id:
           _eq: X-Hasura-User-Id
       check:
         id:
           _eq: X-Hasura-User-Id
-      comment: "Users can only update their own last_seen timestamp"
-  - role: admin
+  - role: landlord
     permission:
       columns:
-        - email
-        - last_seen
+        - first_name
+        - last_name
+        - phone_number
+        - country_code
+        - location
       filter:
         id:
-          _neq: ""
+          _eq: X-Hasura-User-Id
       check:
         id:
-          _neq: ""
-      comment: "Admins can update user information in their tenant"
-delete_permissions:
-  - role: admin
-    permission:
-      filter:
-        id:
-          _neq: ""
-      comment: "Admins can delete users in their tenant"
+          _eq: X-Hasura-User-Id


### PR DESCRIPTION
Close #367 

### Problem

`metadata/tenants/safetrust/databases/tables/public_users.yaml` was out of sync with the canonical definition in the dApp-SafeTrust monorepo across five concrete divergences:

- Wrong roles (`anonymous`, `user`, `admin` instead of `tenant`, `landlord`)
- Missing columns in `select_permissions` (`firebase_uid`, `first_name`, `last_name`, `phone_number`, `country_code`, `location`)
- Wrong update columns (only `last_seen` instead of profile fields)
- `insert_permissions` and `delete_permissions` present — user lifecycle is handled by Firebase auth webhook, not GraphQL mutations
- `firebase_uid` (a `NOT NULL` field) completely absent from exposed columns

### Solution

Replaced the file contents to exactly mirror the dApp-SafeTrust canonical schema:

- **Roles:** `tenant` and `landlord` only — removed `anonymous`, `user`, `admin`
- **`select_permissions`:** exposes all 9 columns for both roles: `id`, `firebase_uid`, `email`, `first_name`, `last_name`, `phone_number`, `country_code`, `location`, `last_seen`
- **`update_permissions`:** restricted to profile fields only — `first_name`, `last_name`, `phone_number`, `country_code`, `location`
- **`insert_permissions`:** removed entirely
- **`delete_permissions`:** removed entirely
- **Row-level security:** `id: _eq: X-Hasura-User-Id` preserved on all permissions
- **`array_relationships`** to `user_wallets`: unchanged

### Files Changed

- `metadata/tenants/safetrust/databases/tables/public_users.yaml`

### Validation Checklist

- [x] Only `tenant` and `landlord` roles exist
- [x] `select_permissions` exposes all 9 columns for both roles
- [x] `update_permissions` allows only profile fields — not `id`, `email`, `firebase_uid`, or `last_seen`
- [x] No `insert_permissions` or `delete_permissions` present
- [x] `X-Hasura-User-Id` row-level filter applied on all permissions
- [x] `array_relationships` to `user_wallets` unchanged
- [x] `deploy-tenant.sh safetrust` completes with no warnings (local env)
- [x] Hasura console shows correct permissions after metadata reload (local env)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Updated user profile access controls with role-based permissions, restricting data visibility and modifications to individual user profiles only.
  * Limited editable profile fields to essential contact information including name, phone, country code, and location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/safetrustcr/backend-SafeTrust/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->