### PR TITLE
fix: sync bid_requests seed with dApp-SafeTrust canonical

### DIFF
--- a/seeds/safetrust/1734710839892_bid_requests_seed.sql
+++ b/seeds/safetrust/1734710839892_bid_requests_seed.sql
@@ -1,131 +1,48 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- SafeTrust demo bid requests seed
+-- Canonical source: dApp-SafeTrust/infra/hasura/seeds/safetrust/03_bid_requests_seed.sql
+-- Depends on: 1733963959819_user_seed.sql, 1733970410880_apartments_seed.sql (must run after both)
 
-INSERT INTO bid_requests (
+-- Idempotency: remove demo bid requests before reinserting
+DELETE FROM public.bid_requests
+WHERE tenant_id IN (
+    SELECT id FROM public.users
+    WHERE firebase_uid = 'demo-tenant-uid-001'
+);
+
+-- Bid Request 1: PENDING on Apartment 1
+INSERT INTO public.bid_requests (
     id,
     apartment_id,
     tenant_id,
     current_status,
     proposed_price,
     desired_move_in
-) VALUES 
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Moderno Apartamento en San José Centro' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'julia.martinez@example.com' LIMIT 1),
+)
+SELECT
+    '660e8400-e29b-41d4-a716-446655440001'::uuid,
+    '550e8400-e29b-41d4-a716-446655440001'::uuid,
+    u.id,
     'PENDING',
     1150.00,
-    '2024-02-01T10:00:00Z'
-),
+    NOW() + INTERVAL '1 month'
+FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+ON CONFLICT (id) DO NOTHING;
 
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Suite Ejecutiva Sabana Norte' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'thomas.mueller@example.com' LIMIT 1),
-    'APPROVED',
+-- Bid Request 2: CANCELLED on Apartment 2
+INSERT INTO public.bid_requests (
+    id,
+    apartment_id,
+    tenant_id,
+    current_status,
+    proposed_price,
+    desired_move_in
+)
+SELECT
+    '660e8400-e29b-41d4-a716-446655440002'::uuid,
+    '550e8400-e29b-41d4-a716-446655440002'::uuid,
+    u.id,
+    'CANCELLED',
     900.00,
-    '2024-03-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Penthouse de Lujo en Escazú' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'sarah.johnson@example.com' LIMIT 1),
-    'PENDING',
-    2300.00,
-    '2024-04-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Apartamento Familiar en Santa Ana' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'lucas.silva@example.com' LIMIT 1),
-    'CANCELLED',
-    1700.00,
-    '2024-03-15T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Estudio Moderno en Heredia Centro' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'emma.brown@example.com' LIMIT 1),
-    'APPROVED',
-    580.00,
-    '2024-02-15T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Apartamento Estudiantil en Cartago' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'antoine.dupont@example.com' LIMIT 1),
-    'PENDING',
-    425.00,
-    '2024-05-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Suite Frente al Mar en Jacó' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'sofia.garcia@example.com' LIMIT 1),
-    'APPROVED',
-    1050.00,
-    '2024-06-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Apartamento Ejecutivo San Pedro' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'marco.rossi@example.com' LIMIT 1),
-    'PENDING',
-    850.00,
-    '2024-04-15T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Loft Amueblado Santa Ana' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'anna.kowalski@example.com' LIMIT 1),
-    'CANCELLED',
-    1200.00,
-    '2024-03-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Vista Montaña Heredia' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'james.wilson@example.com' LIMIT 1),
-    'APPROVED',
-    1050.00,
-    '2024-07-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Apartamento Familiar Alajuela' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'hans.schmidt@example.com' LIMIT 1),
-    'PENDING',
-    800.00,
-    '2024-05-15T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Eco Apartamento Monteverde' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'marie.dubois@example.com' LIMIT 1),
-    'APPROVED',
-    900.00,
-    '2024-06-15T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Mini Apartamento San José' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'alessandro.conti@example.com' LIMIT 1),
-    'PENDING',
-    480.00,
-    '2024-04-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Luxury Condo Escazú' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'isabel.santos@example.com' LIMIT 1),
-    'CANCELLED',
-    2800.00,
-    '2024-08-01T10:00:00Z'
-),
-(
-    uuid_generate_v4(),
-    (SELECT id FROM apartments WHERE name = 'Student Housing Heredia' LIMIT 1),
-    (SELECT id FROM users WHERE email = 'john.smith@example.com' LIMIT 1),
-    'APPROVED',
-    380.00,
-    '2024-03-01T10:00:00Z'
-);
+    NOW() + INTERVAL '2 months'
+FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+ON CONFLICT (id) DO NOTHING;

--- a/seeds/safetrust/1735509833667_create_bid_status_histories.sql
+++ b/seeds/safetrust/1735509833667_create_bid_status_histories.sql
@@ -1,27 +1,45 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- SafeTrust demo bid status histories seed
+-- Depends on: 1734710839892_bid_requests_seed.sql (must run after bid_requests)
 
--- Clear existing seed data (development only)
-TRUNCATE bid_status_histories RESTART IDENTITY CASCADE;
+-- Idempotency: remove demo bid status histories before reinserting
+DELETE FROM public.bid_status_histories
+WHERE bid_request_id IN (
+    '660e8400-e29b-41d4-a716-446655440001'::uuid,
+    '660e8400-e29b-41d4-a716-446655440002'::uuid
+);
 
-INSERT INTO bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
-VALUES
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 0), 'Submitted', 'Bid request has been submitted.', (SELECT id FROM users LIMIT 1 OFFSET 0), NOW()),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 1), 'Reviewed', 'Initial review completed by team lead.', (SELECT id FROM users LIMIT 1 OFFSET 1), NOW() - INTERVAL '1 day'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 2), 'Approved', 'Bid request approved by manager.', (SELECT id FROM users LIMIT 1 OFFSET 2), NOW() - INTERVAL '2 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 3), 'In_Progress', 'Work on the bid has begun.', (SELECT id FROM users LIMIT 1 OFFSET 3), NOW() - INTERVAL '3 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 4), 'Rejected', 'Bid request rejected due to insufficient budget.', (SELECT id FROM users LIMIT 1 OFFSET 4), NOW() - INTERVAL '4 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 5), 'Completed', 'All tasks related to the bid request have been completed.', (SELECT id FROM users LIMIT 1 OFFSET 5), NOW() - INTERVAL '5 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 6), 'Rejected', 'incorrect info.', (SELECT id FROM users LIMIT 1 OFFSET 6), NOW() - INTERVAL '5 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 7), 'Submitted', 'Bid request has been submitted.', (SELECT id FROM users LIMIT 1 OFFSET 7), NOW() - INTERVAL '5 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 8), 'In_Progress', 'Awaiting approval.', (SELECT id FROM users LIMIT 1 OFFSET 8), NOW() - INTERVAL '9 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 9), 'Approved', 'Reviewed and approved.', (SELECT id FROM users LIMIT 1 OFFSET 9), NOW() - INTERVAL '6 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 10), 'Rejected', 'Bid amount exceeded limit.', (SELECT id FROM users LIMIT 1 OFFSET 10), NOW() - INTERVAL '2 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 11), 'Approved', 'Bid has been finalized.', (SELECT id FROM users LIMIT 1 OFFSET 11), NOW() - INTERVAL '6 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 12), 'Submitted', 'Initial status set.', (SELECT id FROM users LIMIT 1 OFFSET 12), NOW() - INTERVAL '10 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 13), 'In_Progress', 'Work on the bid has begun.', (SELECT id FROM users LIMIT 1 OFFSET 13), NOW() - INTERVAL '3 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 14), 'Rejected', 'Insufficient details provided.', (SELECT id FROM users LIMIT 1 OFFSET 14), NOW() - INTERVAL '4 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 15), 'Completed', 'All tasks related to the bid request have been completed.', (SELECT id FROM users LIMIT 1 OFFSET 15), NOW() - INTERVAL '5 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 16), 'Approved', 'Successfully met all requirements', (SELECT id FROM users LIMIT 1 OFFSET 16), NOW() - INTERVAL '5 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 17), 'Submitted', 'Bid request has been submitted.', (SELECT id FROM users LIMIT 1 OFFSET 17), NOW() - INTERVAL '5 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 18), 'In_Progress', 'Waiting on additional documentation', (SELECT id FROM users LIMIT 1 OFFSET 18), NOW() - INTERVAL '9 days'),
-    (uuid_generate_v4(), (SELECT id FROM bid_requests LIMIT 1 OFFSET 19), 'Approved', 'Reviewed and approved.', (SELECT id FROM users LIMIT 1 OFFSET 19), NOW() - INTERVAL '6 days');
+-- Status history for Bid Request 1 (PENDING on Apartment 1)
+INSERT INTO public.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
+SELECT
+    '770e8400-e29b-41d4-a716-446655440001'::uuid,
+    '660e8400-e29b-41d4-a716-446655440001'::uuid,
+    'Submitted',
+    'Bid request has been submitted.',
+    u.id,
+    NOW()
+FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+ON CONFLICT (id) DO NOTHING;
+
+-- Status history for Bid Request 2 (CANCELLED on Apartment 2) — entry 1: Submitted
+INSERT INTO public.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
+SELECT
+    '770e8400-e29b-41d4-a716-446655440002'::uuid,
+    '660e8400-e29b-41d4-a716-446655440002'::uuid,
+    'Submitted',
+    'Bid request has been submitted.',
+    u.id,
+    NOW() - INTERVAL '1 day'
+FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+ON CONFLICT (id) DO NOTHING;
+
+-- Status history for Bid Request 2 (CANCELLED on Apartment 2) — entry 2: Cancelled
+INSERT INTO public.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
+SELECT
+    '770e8400-e29b-41d4-a716-446655440003'::uuid,
+    '660e8400-e29b-41d4-a716-446655440002'::uuid,
+    'Cancelled',
+    'Bid request cancelled by tenant.',
+    u.id,
+    NOW()
+FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

Closes #373

- **Stable UUIDs**: Replace `uuid_generate_v4()` with explicit UUID literals (`660e8400-e29b-41d4-a716-446655440001/002`) so dependent seeds (`bid_status_histories`, `escrow_transactions`) can reference bid requests by a stable FK
- **Stable apartment references**: Replace name-based apartment lookups (`WHERE name = '...'`) with stable UUID literals (`550e8400-e29b-41d4-a716-446655440001/002`) from the apartments seed
- **Canonical tenant lookup**: Replace email-based user lookups with `firebase_uid = 'demo-tenant-uid-001'` to align with the canonical user seed format
- **Idempotency**: Add a scoped `DELETE` guard before inserts and `ON CONFLICT (id) DO NOTHING` on all inserts — repeated `hasura seed apply` runs insert exactly 2 rows, not N×2
- **Schema prefix**: All table references now use `public.` prefix for multi-tenant Hasura reliability
- **Remove extension**: Drop `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"` — no longer needed after moving to literal UUIDs
- **Reduce scope**: Replace 15 non-deterministic demo rows with 2 canonical bid requests matching the dApp-SafeTrust reference implementation
- **bid_status_histories**: Replace `TRUNCATE … RESTART IDENTITY CASCADE` and `OFFSET`-based lookups with stable bid_request UUID references, `firebase_uid` tenant lookup, `DELETE` idempotency guard, and `ON CONFLICT (id) DO NOTHING`
