### PR TITLE
fix: sync public_user_wallets metadata with canonical SafeTrust schema

### DIFF
--- a/metadata/tenants/safetrust/databases/tables/public_user_wallets.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_user_wallets.yaml
@@ -6,12 +6,7 @@ object_relationships:
     using:
       foreign_key_constraint_on: user_id
 select_permissions:
-  - role: anonymous
-    permission:
-      columns: []
-      filter: {}
-    comment: "Anonymous users cannot access any wallet data"
-  - role: user
+  - role: landlord
     permission:
       columns:
         - id
@@ -22,11 +17,10 @@ select_permissions:
         - created_at
         - updated_at
       filter:
-        # Row-level security: users can only see their own wallets
         user_id:
           _eq: X-Hasura-User-Id
-      comment: "Users can only see their own wallets"
-  - role: admin
+      comment: "Landlords can only see their own wallets"
+  - role: tenant
     permission:
       columns:
         - id
@@ -37,16 +31,13 @@ select_permissions:
         - created_at
         - updated_at
       filter:
-        # Admins can see all wallets in their tenant
-        user:
-          id:
-            _neq: ""
-      comment: "Admins can view all wallets within their tenant"
+        user_id:
+          _eq: X-Hasura-User-Id
+      comment: "Tenants can only see their own wallets"
 insert_permissions:
-  - role: user
+  - role: landlord
     permission:
       check:
-        # Row-level security: users can only add wallets for themselves
         user_id:
           _eq: X-Hasura-User-Id
       columns:
@@ -54,63 +45,55 @@ insert_permissions:
         - chain_type
         - is_primary
       set:
-        # Automatically set the user_id to the current user
         user_id: X-Hasura-User-Id
-        created_at: now
-      comment: "Users can add their own wallets"
-  - role: admin
+        created_at: "now()"
+      comment: "Landlords can add their own wallets"
+  - role: tenant
     permission:
       check:
-        user:
-          id:
-            _neq: ""
+        user_id:
+          _eq: X-Hasura-User-Id
       columns:
-        - user_id
         - wallet_address
         - chain_type
         - is_primary
-      comment: "Admins can add wallets for users in their tenant"
+      set:
+        user_id: X-Hasura-User-Id
+        created_at: "now()"
+      comment: "Tenants can add their own wallets"
 update_permissions:
-  - role: user
+  - role: landlord
     permission:
       columns:
         - is_primary
       filter:
-        # Row-level security: users can only update their own wallets
         user_id:
           _eq: X-Hasura-User-Id
       check:
         user_id:
           _eq: X-Hasura-User-Id
-      comment: "Users can update their own wallet settings"
-  - role: admin
+      comment: "Landlords can update their own wallet settings"
+  - role: tenant
     permission:
       columns:
-        - wallet_address
-        - chain_type
         - is_primary
-        - updated_at
       filter:
-        user:
-          id:
-            _neq: ""
+        user_id:
+          _eq: X-Hasura-User-Id
       check:
-        user:
-          id:
-            _neq: ""
-      comment: "Admins can manage user wallets in their tenant"
+        user_id:
+          _eq: X-Hasura-User-Id
+      comment: "Tenants can update their own wallet settings"
 delete_permissions:
-  - role: user
+  - role: landlord
     permission:
       filter:
-        # Row-level security: users can delete their own wallets
         user_id:
           _eq: X-Hasura-User-Id
-      comment: "Users can delete their own wallets"
-  - role: admin
+      comment: "Landlords can delete their own wallets"
+  - role: tenant
     permission:
       filter:
-        user:
-          id:
-            _neq: ""
-      comment: "Admins can delete any wallet in their tenant"
+        user_id:
+          _eq: X-Hasura-User-Id
+      comment: "Tenants can delete their own wallets"


### PR DESCRIPTION
# Summary

 Closes #368 
This PR resolves metadata drift in the `public_user_wallets.yaml` Hasura configuration and synchronizes the backend-SafeTrust tenant metadata with the canonical definition from the dApp-SafeTrust monorepo.

Closes:

* #368 — [bug] public_user_wallets.yaml metadata out of sync with dApp-SafeTrust canonical

---

# What Changed

## Role Alignment

Replaced outdated roles:

* `anonymous`
* `user`
* `admin`

with the canonical SafeTrust domain roles:

* `tenant`
* `landlord`

This now matches:

* `public_users.yaml`
* SafeTrust business-domain semantics
* canonical dApp-SafeTrust metadata structure

---

# created_at Preset Fix

Fixed incorrect insert preset:

Before:

```yaml
created_at: now
```

After:

```yaml
created_at: "now()"
```

This ensures PostgreSQL evaluates the timestamp function correctly instead of storing the literal string `"now"`.

---

# Permission Hardening

## Removed Overly Broad Admin Permissions

Deleted all admin update/delete permissions.

The wallet lifecycle is now fully self-managed by:

* tenant
* landlord

---

## Update Permission Restrictions

Both tenant and landlord may now update ONLY:

* `is_primary`

The following fields are no longer mutable:

* `wallet_address`
* `chain_type`
* `created_at`
* `updated_at`

This prevents unauthorized wallet mutation.

---

# Symmetric Role Permissions

Ensured permission parity between:

* tenant
* landlord

Across:

* select_permissions
* insert_permissions
* update_permissions
* delete_permissions

---

# Row-Level Security Preservation

Preserved all RLS filters:

```yaml
user_id:
  _eq: X-Hasura-User-Id
```

This guarantees users can only:

* view their own wallets
* modify their own wallets
* delete their own wallets

---

# Object Relationships

Preserved:

```yaml
object_relationships:
  - name: user
```

No relationship behavior was modified.

---

# Validation Performed

Verified:

* metadata deploy succeeds
* metadata reload succeeds
* tenant/landlord permissions appear correctly in Hasura console
* anonymous/user/admin roles removed
* inserts correctly generate timestamps
* wallet_address update attempts fail
* row-level visibility works correctly

---

# Security Improvements

This PR improves:

* metadata consistency
* RLS correctness
* privilege minimization
* timestamp correctness
* domain-role alignment

---

# Checklist

* [x] Closes #368
* [x] Synced metadata with canonical dApp-SafeTrust schema
* [x] Replaced anonymous/user/admin with tenant/landlord
* [x] Fixed created_at preset to use "now()"
* [x] Removed admin update/delete permissions
* [x] Preserved row-level security filters
* [x] Restricted updates to is_primary only
* [x] Preserved object relationships
* [x] Verified metadata deployment and reload
* [x] Validated Hasura permissions behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined user wallet access controls with stricter role-based permissions and row-level filtering.
  * Enhanced data privacy by ensuring users can only access and modify their own wallet records.
  * Updated security boundaries for different user roles to prevent unauthorized cross-user data access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/safetrustcr/backend-SafeTrust/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->