### PR TITLE
fix: sync user seed with canonical dApp-SafeTrust schema (#371)

### DIFF
--- a/seeds/safetrust/1733963959819_user_seed.sql
+++ b/seeds/safetrust/1733963959819_user_seed.sql
@@ -1,33 +1,42 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- SafeTrust demo seed users
+-- id must be TEXT (Firebase UID format), not UUID
+-- On conflict: skip — safe for repeated seed apply runs
 
--- Clear existing seed data (development only)
-TRUNCATE users RESTART IDENTITY CASCADE;
-
--- Users seed data
-INSERT INTO users (id, email, first_name, last_name, last_seen)
+INSERT INTO public.users (
+    id,
+    firebase_uid,
+    email,
+    first_name,
+    last_name,
+    phone_number,
+    country_code,
+    location,
+    last_seen
+)
 VALUES
-    (uuid_generate_v4(), 'maria.rodriguez@example.com', 'Maria', 'Rodriguez', '2024-12-10T19:30:00Z'),
-    (uuid_generate_v4(), 'carlos.jimenez@example.com', 'Carlos', 'Jimenez', '2024-12-10T18:30:00Z'),
-    (uuid_generate_v4(), 'ana.castro@example.com', 'Ana', 'Castro', '2024-12-09T15:30:00Z'),
-    (uuid_generate_v4(), 'roberto.mora@example.com', 'Roberto', 'Mora', '2024-12-08T14:30:00Z'),
-    (uuid_generate_v4(), 'laura.vargas@example.com', 'Laura', 'Vargas', '2024-12-07T13:30:00Z'),
-    (uuid_generate_v4(), 'pedro.solano@example.com', 'Pedro', 'Solano', '2024-12-06T12:30:00Z'),
-    (uuid_generate_v4(), 'sofia.mendez@example.com', 'Sofia', 'Mendez', '2024-12-05T11:30:00Z'),
-    (uuid_generate_v4(), 'diego.campos@example.com', 'Diego', 'Campos', '2024-12-04T10:30:00Z'),
-    (uuid_generate_v4(), 'carmen.rojas@example.com', 'Carmen', 'Rojas', '2024-12-03T09:30:00Z'),
-    (uuid_generate_v4(), 'miguel.herrera@example.com', 'Miguel', 'Herrera', '2024-12-02T08:30:00Z'),
-    (uuid_generate_v4(), 'julia.martinez@example.com', 'Julia', 'Martinez', '2024-12-01T07:30:00Z'),
-    (uuid_generate_v4(), 'thomas.mueller@example.com', 'Thomas', 'Mueller', '2024-11-30T06:30:00Z'),
-    (uuid_generate_v4(), 'sarah.johnson@example.com', '2024-11-29T05:30:00Z'),
-    (uuid_generate_v4(), 'lucas.silva@example.com', '2024-11-28T04:30:00Z'),
-    (uuid_generate_v4(), 'emma.brown@example.com', '2024-11-27T03:30:00Z'),
-    (uuid_generate_v4(), 'antoine.dupont@example.com', '2024-11-26T02:30:00Z'),
-    (uuid_generate_v4(), 'sofia.garcia@example.com', '2024-11-25T01:30:00Z'),
-    (uuid_generate_v4(), 'marco.rossi@example.com', '2024-11-24T00:30:00Z'),
-    (uuid_generate_v4(), 'anna.kowalski@example.com', '2024-11-23T23:30:00Z'),
-    (uuid_generate_v4(), 'james.wilson@example.com', '2024-11-22T22:30:00Z'),
-    (uuid_generate_v4(), 'hans.schmidt@example.com', '2024-11-21T21:30:00Z'),
-    (uuid_generate_v4(), 'marie.dubois@example.com', '2024-11-20T20:30:00Z'),
-    (uuid_generate_v4(), 'alessandro.conti@example.com', '2024-11-19T19:30:00Z'),
-    (uuid_generate_v4(), 'isabel.santos@example.com', '2024-11-18T18:30:00Z'),
-    (uuid_generate_v4(), 'john.smith@example.com', '2024-11-17T17:30:00Z');
+    ('demo-uid-001', 'demo-uid-001', 'maria.rodriguez@example.com', 'Maria', 'Rodriguez', '87654321', '+506', 'San José, Costa Rica', '2024-12-10T19:30:00Z'),
+    ('demo-uid-002', 'demo-uid-002', 'carlos.jimenez@example.com', 'Carlos', 'Jimenez', '88776655', '+506', 'Escazú, Costa Rica', '2024-12-10T18:30:00Z'),
+    ('demo-uid-003', 'demo-uid-003', 'ana.castro@example.com', 'Ana', 'Castro', '89897676', '+506', 'Heredia, Costa Rica', '2024-12-09T15:30:00Z'),
+    ('demo-uid-004', 'demo-uid-004', 'roberto.mora@example.com', 'Roberto', 'Mora', '84848484', '+506', 'Cartago, Costa Rica', '2024-12-08T14:30:00Z'),
+    ('demo-uid-005', 'demo-uid-005', 'laura.vargas@example.com', 'Laura', 'Vargas', '83838383', '+506', 'Jacó, Costa Rica', '2024-12-07T13:30:00Z'),
+    ('demo-uid-006', 'demo-uid-006', 'pedro.solano@example.com', 'Pedro', 'Solano', '82828282', '+506', 'San José, Costa Rica', '2024-12-06T12:30:00Z'),
+    ('demo-uid-007', 'demo-uid-007', 'sofia.mendez@example.com', 'Sofia', 'Mendez', '81818181', '+506', 'Santa Ana, Costa Rica', '2024-12-05T11:30:00Z'),
+    ('demo-uid-008', 'demo-uid-008', 'diego.campos@example.com', 'Diego', 'Campos', '80808080', '+506', 'Heredia, Costa Rica', '2024-12-04T10:30:00Z'),
+    ('demo-uid-009', 'demo-uid-009', 'carmen.rojas@example.com', 'Carmen', 'Rojas', '79797979', '+506', 'Alajuela, Costa Rica', '2024-12-03T09:30:00Z'),
+    ('demo-uid-010', 'demo-uid-010', 'miguel.herrera@example.com', 'Miguel', 'Herrera', '78787878', '+506', 'Monteverde, Costa Rica', '2024-12-02T08:30:00Z'),
+    ('demo-uid-011', 'demo-uid-011', 'julia.martinez@example.com', 'Julia', 'Martinez', '77777777', '+34', 'Madrid, Spain', '2024-12-01T07:30:00Z'),
+    ('demo-uid-012', 'demo-uid-012', 'thomas.mueller@example.com', 'Thomas', 'Mueller', '76767676', '+49', 'Berlin, Germany', '2024-11-30T06:30:00Z'),
+    ('demo-uid-013', 'demo-uid-013', 'sarah.johnson@example.com', 'Sarah', 'Johnson', '75757575', '+1', 'New York, USA', '2024-11-29T05:30:00Z'),
+    ('demo-uid-014', 'demo-uid-014', 'lucas.silva@example.com', 'Lucas', 'Silva', '74747474', '+55', 'São Paulo, Brazil', '2024-11-28T04:30:00Z'),
+    ('demo-uid-015', 'demo-uid-015', 'emma.brown@example.com', 'Emma', 'Brown', '73737373', '+44', 'London, UK', '2024-11-27T03:30:00Z'),
+    ('demo-uid-016', 'demo-uid-016', 'antoine.dupont@example.com', 'Antoine', 'Dupont', '72727272', '+33', 'Paris, France', '2024-11-26T02:30:00Z'),
+    ('demo-uid-017', 'demo-uid-017', 'sofia.garcia@example.com', 'Sofia', 'Garcia', '71717171', '+34', 'Barcelona, Spain', '2024-11-25T01:30:00Z'),
+    ('demo-uid-018', 'demo-uid-018', 'marco.rossi@example.com', 'Marco', 'Rossi', '70707070', '+39', 'Rome, Italy', '2024-11-24T00:30:00Z'),
+    ('demo-uid-019', 'demo-uid-019', 'anna.kowalski@example.com', 'Anna', 'Kowalski', '69696969', '+48', 'Warsaw, Poland', '2024-11-23T23:30:00Z'),
+    ('demo-uid-020', 'demo-uid-020', 'james.wilson@example.com', 'James', 'Wilson', '68686868', '+1', 'Toronto, Canada', '2024-11-22T22:30:00Z'),
+    ('demo-uid-021', 'demo-uid-021', 'hans.schmidt@example.com', 'Hans', 'Schmidt', '67676767', '+49', 'Munich, Germany', '2024-11-21T21:30:00Z'),
+    ('demo-uid-022', 'demo-uid-022', 'marie.dubois@example.com', 'Marie', 'Dubois', '66666666', '+33', 'Lyon, France', '2024-11-20T20:30:00Z'),
+    ('demo-uid-023', 'demo-uid-023', 'alessandro.conti@example.com', 'Alessandro', 'Conti', '65656565', '+39', 'Milan, Italy', '2024-11-19T19:30:00Z'),
+    ('demo-uid-024', 'demo-uid-024', 'isabel.santos@example.com', 'Isabel', 'Santos', '64646464', '+351', 'Lisbon, Portugal', '2024-11-18T18:30:00Z'),
+    ('demo-uid-025', 'demo-uid-025', 'john.smith@example.com', 'John', 'Smith', '63636363', '+1', 'San Francisco, USA', '2024-11-17T17:30:00Z')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Closes #371 

## fix: sync user seed with canonical dApp-SafeTrust schema (#371)

### Summary

The file `seeds/safetrust/1733963959819_user_seed.sql` was out of sync with the canonical implementation at `dApp-SafeTrust/infra/hasura/seeds/safetrust/01_users_seed.sql`, causing seed failures, FK constraint breaks, and auth flow mismatches.

### Changes

**File modified:** `seeds/safetrust/1733963959819_user_seed.sql`

| # | Problem | Fix |
|---|---------|-----|
| 1 | `id` generated as `uuid_generate_v4()` — breaks Firebase UID assumption | Replaced with `'demo-uid-NNN'` TEXT literals |
| 2 | Missing `firebase_uid`, `phone_number`, `country_code`, `location` columns — `firebase_uid` is `NOT NULL`, seed would fail entirely | Added all four columns to column list and every row |
| 3 | `INSERT INTO users` — unreliable in multi-tenant Hasura | Changed to `INSERT INTO public.users` |
| 4 | `TRUNCATE users RESTART IDENTITY CASCADE` — destructive, wipes all dependent seed data | Replaced with `ON CONFLICT (id) DO NOTHING` |
| 5 | `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"` — no longer needed | Removed |
| 6 | Rows 13–25 (`sarah.johnson` onward) missing `first_name` and `last_name` — timestamp passed as third column | All 25 rows now have correct `first_name` and `last_name` |

### Validation

- All 25 demo users retained with corrected structure
- `id` and `firebase_uid` are TEXT in `demo-uid-NNN` format and match for all rows
- `phone_number`, `country_code`, `location` present for all 25 rows
- All inserts target `public.users` explicitly
- `ON CONFLICT (id) DO NOTHING` — seed apply is fully idempotent (running twice yields 25 rows, not 50)
- Dependent seeds (`user_wallets`, `bid_requests`, `departments`, `bid_status_histories`) resolve users by `email` or `OFFSET` — unaffected by id type change ✅

### Testing

```sql
-- Verify 25 rows with all required fields
SELECT id, firebase_uid, email, phone_number, country_code, location
FROM public.users
ORDER BY last_seen DESC;
-- Expected: 25 rows

-- Verify idempotency
SELECT COUNT(*) FROM public.users;
-- Expected: 25 (not 50 after two seed applies)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo user seeding strategy to include additional user profile fields and use deterministic user identifiers for consistent testing.
  * Made database seeding process more robust by implementing idempotent insertions to prevent conflicts on repeated runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/safetrustcr/backend-SafeTrust/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->