### PR TITLE
Feat/388 seed default roles

### DIFF
--- a/migrations/safetrust/1776100000000_create_roles/down.sql
+++ b/migrations/safetrust/1776100000000_create_roles/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.roles;

--- a/migrations/safetrust/1776100000000_create_roles/up.sql
+++ b/migrations/safetrust/1776100000000_create_roles/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE public.roles (
+  id   SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+COMMENT ON TABLE public.roles
+  IS 'Application roles: admin, host, guest';
+
+CREATE INDEX idx_roles_name
+  ON public.roles(name);

--- a/migrations/safetrust/1776100000002_seed_default_roles/down.sql
+++ b/migrations/safetrust/1776100000002_seed_default_roles/down.sql
@@ -1,0 +1,2 @@
+DELETE FROM public.roles
+WHERE name IN ('admin', 'host', 'guest');

--- a/migrations/safetrust/1776100000002_seed_default_roles/up.sql
+++ b/migrations/safetrust/1776100000002_seed_default_roles/up.sql
@@ -1,0 +1,6 @@
+INSERT INTO public.roles (name)
+VALUES
+  ('admin'),
+  ('host'),
+  ('guest')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
#closes #388 

❗ **Pull Request Information**

This pull request implements the third migration in Batch A — Role System Foundation for the SafeTrust platform. It seeds the three default roles (admin, host, guest) into the `public.roles` table. Without these rows, no user can be assigned a role and the entire auth routing system has no data to work with. The migration uses `ON CONFLICT DO NOTHING` to ensure it is idempotent and safe to run multiple times.

## 🌀 Summary of Changes

- **Created migration directory**: `migrations/safetrust/1776100000002_seed_default_roles/`
- **Added up.sql migration**: Inserts the three default roles:
  - `admin` — Super user with full access to all data and admin panel
  - `host` — Property owner who creates apartments and manages escrows
  - `guest` — Tenant who browses listings, books, and pays via escrow
- **Implemented idempotency**: Uses `ON CONFLICT (name) DO NOTHING` to prevent duplicate rows on repeated runs
- **Added down.sql migration**: Removes only the three seeded roles for clean rollback

## 🛠 Testing

### Evidence Before Solution

The `public.roles` table existed but was empty. Without seeded role data, the role-based access control system could not function, as no users could be assigned to roles.

### Evidence After Solution

The migration successfully seeds the three default roles:
- Three rows inserted: admin (id=1), host (id=2), guest (id=3)
- Migration is idempotent — running twice produces no duplicates
- Rollback cleanly removes only the seeded roles
- `hasura migrate apply` runs without errors

### Verification Steps

1. **Start Docker containers**:
   ```bash
   bin/dc_prep
   ```

2. **Apply the migration**:
   ```bash
   cd migrations
   hasura migrate apply
   ```
   Select `safetrust` when prompted.

3. **Verify roles were seeded**:
   ```bash
   docker exec safetrust-postgres psql -U postgres -d postgres -c "SELECT id, name FROM public.roles ORDER BY id;"
   ```
   Expected output:
   ```
    id |  name
   ----+-------
     1 | admin
     2 | host
     3 | guest
   ```

4. **Test idempotency (run migration twice)**:
   ```bash
   cd migrations
   hasura migrate apply --database-name safetrust
   hasura migrate apply --database-name safetrust
   ```
   Expected behavior: Second run produces no error and no duplicate rows.

5. **Verify no duplicates after idempotency test**:
   ```bash
   docker exec safetrust-postgres psql -U postgres -d postgres -c "SELECT COUNT(*) FROM public.roles;"
   ```
   Expected output: `3` (exactly 3 rows, no duplicates)

6. **Test down migration**:
   ```bash
   cd migrations
   hasura migrate apply --down 1
   ```
   Select `safetrust` when prompted.

7. **Verify roles were removed**:
   ```bash
   docker exec safetrust-postgres psql -U postgres -d postgres -c "SELECT COUNT(*) FROM public.roles;"
   ```
   Expected output: `0` (all three seeded roles removed)

8. **Re-apply migration** (to restore roles):
   ```bash
   cd migrations
   hasura migrate apply
   ```
   Select `safetrust` when prompted.

9. **Final verification**:
   ```bash
   docker exec safetrust-postgres psql -U postgres -d postgres -c "SELECT id, name FROM public.roles ORDER BY id;"
   ```
   Expected output:
   ```
    id |  name
   ----+-------
     1 | admin
     2 | host
     3 | guest
   ```

## 📂 Related Issue

This pull request will **close #388** upon merging.

**Dependencies:**
- Depends on #386: feat(db): create public.roles table
- Depends on #387: feat(db): create public.user_roles join table

---

## Role Definitions

| Role   | Description                                                      |
|--------|------------------------------------------------------------------|
| admin  | Super user — full access to all data and admin panel            |
| host   | Property owner — creates apartments, manages escrows            |
| guest  | Tenant — browses listings, books, pays via escrow               |

---

## Acceptance Criteria

- ✅ Migration created at correct timestamp path (`migrations/safetrust/1776100000002_seed_default_roles/`)
- ✅ admin, host, guest rows inserted into public.roles
- ✅ ON CONFLICT DO NOTHING — migration is idempotent
- ✅ down.sql removes only the three seeded rows
- ✅ hasura migrate apply runs without errors
- ✅ Running twice produces no duplicates and no errors
- ✅ SELECT * FROM public.roles returns exactly 3 rows

---

🎉 Thank you for reviewing this PR! 🎉

#closes 