### PR TITLE
feat: create the public.user_roles join table in the safetrust tenant

### DIFF
--- a/migrations/safetrust/1776100000001_create_user_roles/down.sql
+++ b/migrations/safetrust/1776100000001_create_user_roles/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.user_roles;

--- a/migrations/safetrust/1776100000001_create_user_roles/up.sql
+++ b/migrations/safetrust/1776100000001_create_user_roles/up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE public.user_roles (
+  id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id    TEXT        NOT NULL
+             REFERENCES public.users(id) ON DELETE CASCADE,
+  role_id    INTEGER     NOT NULL
+             REFERENCES public.roles(id) ON DELETE CASCADE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+  UNIQUE (user_id, role_id)
+);
+
+CREATE INDEX idx_user_roles_user_id
+  ON public.user_roles(user_id);
+
+CREATE INDEX idx_user_roles_role_id
+  ON public.user_roles(role_id);
+
+COMMENT ON TABLE public.user_roles
+  IS 'Join table — one user can have multiple roles';
+
+COMMENT ON COLUMN public.user_roles.user_id
+  IS 'References public.users(id) — Firebase UID';
+
+COMMENT ON COLUMN public.user_roles.role_id
+  IS 'References public.roles(id)';


### PR DESCRIPTION
close #387 

Description
Add migration migrations/safetrust/1776100000001_create_user_roles with up.sql and down.sql.
up.sql creates public.user_roles with id as UUID DEFAULT gen_random_uuid() primary key, user_id referencing public.users(id) ON DELETE CASCADE, role_id referencing public.roles(id) ON DELETE CASCADE, created_at timestamp, and a UNIQUE (user_id, role_id) constraint.
up.sql also creates indexes idx_user_roles_user_id and idx_user_roles_role_id and adds table/column comments documenting the join semantics.
down.sql cleanly drops public.user_roles using DROP TABLE IF EXISTS public.user_roles;.
Testing
Verified both files exist and contain the expected SQL patterns with test -f ... and rg, and the checks succeeded.
Attempted to run bin/dc_prep to apply the migration, but it failed in this environment because docker is not installed (automated environment limitation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure to support user role assignment and management, enabling flexible role-based access control and permission assignment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->