### PR TITLE
Fix failing GET /api/apartments/:id Karate scenarios

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk-alpine
+FROM eclipse-temurin:17-jdk-jammy
 
 WORKDIR /app
 

--- a/tests/karate/features/apartments/get_one_rest.feature
+++ b/tests/karate/features/apartments/get_one_rest.feature
@@ -1,18 +1,22 @@
 Feature: GET /api/apartments/:id REST endpoint
 
 Background:
-* def apiBase = 'http://api:3001'
-* def authHeader = restToken({ sub: 'test-user' })
+# The REST API is served by the `webhook` service (http://webhook:3001).
+* def apiBase = webhookUrl
+# In NODE_ENV=test the auth middleware accepts 'mock-token' and reads the
+# acting user from the x-test-uid header (see webhook/src/middleware/auth.js).
+* def validToken = karate.call('classpath:helpers/get-firebase-token.js')
 
 Scenario: returns 401 without token
 Given url apiBase + '/api/apartments/00000000-0000-0000-0000-000000000000'
 When method get
 Then status 401
-And match response == { error: 'Unauthorized' }
+And match response == { error: 'Unauthorized: No token provided' }
 
 Scenario: returns 404 when apartment does not exist
 Given url apiBase + '/api/apartments/00000000-0000-0000-0000-000000000000'
-And header Authorization = authHeader
+And header Authorization = 'Bearer ' + validToken
+And header x-test-uid = 'test-user'
 When method get
 Then status 404
 And match response == { error: 'Apartment not found' }
@@ -23,7 +27,8 @@ Scenario: returns 200 for existing apartment id (optional)
 * if (!apartmentId) karate.log('Skipping 200 check; set APARTMENT_ID env var to a real UUID')
 * if (!apartmentId) karate.abort()
 Given url apiBase + '/api/apartments/' + apartmentId
-And header Authorization = authHeader
+And header Authorization = 'Bearer ' + validToken
+And header x-test-uid = 'test-user'
 When method get
 Then status 200
 And match response.apartment == { id: '#string', name: '#? _ != null', address: '#present', price_per_month: '#present', bedrooms: '#present', bathrooms: '#present', pet_friendly: '#present', description: '#present', is_promoted: '#present', owner: { name: '#present', email: '#present', walletAddress: '#present' } }


### PR DESCRIPTION
The `get_one_rest` feature was showing red on the dashboard with two of its three scenarios failing. This gets it back to green.

The first problem was the base URL. The feature was talking to `http://api:3001`, but there is no service by that name in `docker-compose-test.yml`. The REST routes live in the `webhook` service on `http://webhook:3001`, so the requests never connected and Karate flagged them right at the method step before any assertion ran.

The 404 scenario was signing its request with `restToken()`, which builds an HS256 JWT. Our auth middleware only trusts real Firebase tokens or the test bypass, so it replied with a 401 and the request never reached the handler. The bid request tests already worked around this by sending `mock-token` with an `x-test-uid` header, which the middleware accepts when `NODE_ENV` is test, so I moved this feature onto the same convention.

The last one was a body mismatch. The no token scenario expected `{ error: 'Unauthorized' }`, but the middleware actually returns `{ error: 'Unauthorized: No token provided' }`. I lined the assertion up with what the service really sends back.

I also bumped the test image base from `eclipse-temurin:17-jdk-alpine` to the jammy variant. The alpine tag has no arm64 manifest, so the Karate image would not build on Apple Silicon. Jammy is multi arch and builds natively on both arm64 and amd64.

All three scenarios pass now and the rest of the suite is untouched.

Closes #400

**Proofs**
<img width="1508" height="954" alt="Screenshot 2026-06-18 at 12 29 35 PM" src="https://github.com/user-attachments/assets/0ca7abac-beab-4f65-ac08-bb4a4566cd40" />
<img width="1512" height="974" alt="Screenshot 2026-06-18 at 12 29 45 PM" src="https://github.com/user-attachments/assets/aa3907b5-3002-42c6-aa96-efebda26a44a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure base environment.

* **Tests**
  * Improved test suite authentication handling and service URL configuration for better test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->