### PR TITLE
Test/dc prep safetrust timings

### DIFF
--- a/bin/dc_prep
+++ b/bin/dc_prep
@@ -27,6 +27,12 @@ fi
 # Capture all positional arguments as the tenant list
 TENANTS=("$@")
 
+TRACK_SAFETRUST_TIMINGS=false
+if [[ "${#TENANTS[@]}" -eq 1 && "${TENANTS[0]}" == "safetrust" ]]; then
+  TRACK_SAFETRUST_TIMINGS=true
+  TIMER_START=$SECONDS
+fi
+
 echo ""
 echo "🚀 Starting SafeTrust backend..."
 echo "   Tenants to deploy: ${TENANTS[*]}"
@@ -35,6 +41,10 @@ echo ""
 # ── 1. Start containers ───────────────────────────────────────────────────────
 echo "📦 Starting containers..."
 docker compose up -d
+
+if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+  TIMING_DOCKER_UP=$((SECONDS - TIMER_START))
+fi
 
 # ── 2. Wait for Hasura to be healthy ─────────────────────────────────────────
 echo "⏳ Waiting for Hasura to be healthy..."
@@ -51,6 +61,11 @@ until curl -sf http://localhost:8080/healthz > /dev/null; do
 done
 
 echo "✅ Hasura is healthy"
+
+if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+  TIMING_HASURA_HEALTH=$((SECONDS - TIMER_START))
+fi
+
 echo ""
 
 # ── 3. Deploy all tenants sequentially ───────────────────────────────────────
@@ -60,6 +75,10 @@ cd metadata
   --endpoint http://localhost:8080 \
   --admin-secret "$HASURA_ADMIN_SECRET"
 cd ..
+
+if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+  TIMING_METADATA_DEPLOY_SAFETRUST=$((SECONDS - TIMER_START))
+fi
 
 echo ""
 
@@ -74,6 +93,10 @@ for TENANT in "${TENANTS[@]}"; do
   echo "   ✅ Migrations applied for $TENANT"
 done
 
+if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+  TIMING_MIGRATIONS_SAFETRUST=$((SECONDS - TIMER_START))
+fi
+
 echo ""
 
 # ── 5. Reload metadata after migrations ──────────────────────────────────────
@@ -81,6 +104,10 @@ echo "📋 Reloading metadata..."
 hasura metadata reload \
   --endpoint http://localhost:8080 \
   --admin-secret "$HASURA_ADMIN_SECRET"
+
+if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+  TIMING_METADATA_RELOAD=$((SECONDS - TIMER_START))
+fi
 
 echo ""
 
@@ -94,6 +121,25 @@ for TENANT in "${TENANTS[@]}"; do
     --database-name "$TENANT"
   echo "   ✅ Seeds applied for $TENANT"
 done
+
+if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+  TIMING_SEEDS_SAFETRUST=$((SECONDS - TIMER_START))
+  TIMING_TOTAL=$((SECONDS - TIMER_START))
+
+  mkdir -p tests/results
+  node -e "
+const t = {
+  docker_up: ${TIMING_DOCKER_UP},
+  hasura_health: ${TIMING_HASURA_HEALTH},
+  metadata_deploy_safetrust: ${TIMING_METADATA_DEPLOY_SAFETRUST},
+  migrations_safetrust: ${TIMING_MIGRATIONS_SAFETRUST},
+  metadata_reload: ${TIMING_METADATA_RELOAD},
+  seeds_safetrust: ${TIMING_SEEDS_SAFETRUST},
+  total: ${TIMING_TOTAL}
+};
+console.log(JSON.stringify(t, null, 2));
+" > tests/results/dc-prep-timings.json
+fi
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 echo ""

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -121,6 +121,7 @@ services:
       tests/karate/features
     volumes:
       - ./tests/results:/app/target/karate-reports
+      - ./tests/results:/app/tests/results
     depends_on:
       postgres_test:
         condition: service_healthy

--- a/tests/karate/features/dc-prep-timings.feature
+++ b/tests/karate/features/dc-prep-timings.feature
@@ -1,0 +1,29 @@
+Feature: dc_prep safetrust — phase timing baseline
+
+  Background:
+    * def fs = Java.type('java.nio.file.Files')
+    * def path = Java.type('java.nio.file.Paths').get('tests/results/dc-prep-timings.json')
+    * def timings = karate.fromString(new java.lang.String(fs.readAllBytes(path)))
+
+  Scenario: All expected safetrust phases are present in the timing report
+    Then match timings contains
+    """
+    {
+      docker_up: '#number',
+      hasura_health: '#number',
+      metadata_deploy_safetrust: '#number',
+      migrations_safetrust: '#number',
+      metadata_reload: '#number',
+      seeds_safetrust: '#number',
+      total: '#number'
+    }
+    """
+
+  Scenario: No individual phase exceeds 120 seconds
+    * def phases = karate.keysOf(timings)
+    * def slowPhases = karate.filter(phases, function(k){ return timings[k] > 120 && k != 'total' })
+    Then match slowPhases == []
+
+  Scenario: Timing report is written to the expected output path
+    * def file = new java.io.File('tests/results/dc-prep-timings.json')
+    Then assert file.exists()


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

Adds machine-readable wall-clock timing checkpoints for `bin/dc_prep safetrust` and a Karate feature that validates the timing report shape and baseline thresholds. No optimization work — this establishes an observable baseline to detect future local setup regressions.

## 🌀 Summary of Changes

- **`bin/dc_prep`**: When invoked with only the `safetrust` tenant, records cumulative `$SECONDS` checkpoints after each setup phase and writes `tests/results/dc-prep-timings.json` at completion.
- **`tests/karate/features/dc-prep-timings.feature`**: Asserts all expected phase keys are present, no individual phase exceeds 120 seconds (excluding `total`), and the report file exists at the expected path.
- **`tests/results/.gitkeep`**: Ensures the results directory is tracked (runtime JSON remains gitignored).
- **`docker-compose-test.yml`**: Mounts `./tests/results` into `/app/tests/results` so the Karate container can read `dc-prep-timings.json` generated on the host after `bin/dc_prep safetrust`.

### Timing report keys (safetrust only)

| Phase | JSON key |
|---|---|
| Docker containers up | `docker_up` |
| Hasura health check | `hasura_health` |
| Tenant metadata deploy | `metadata_deploy_safetrust` |
| Migrations | `migrations_safetrust` |
| Metadata reload | `metadata_reload` |
| Seeds | `seeds_safetrust` |
| Total elapsed | `total` |

**Note:** Timing output is emitted only for `bin/dc_prep safetrust` (single-tenant run). Multi-tenant invocations are unchanged.

**Implementation detail:** Uses plain scalar bash variables instead of `declare -A` for compatibility with macOS Bash 3.2.

## 🛠 Testing

### Evidence Before Solution

- Running `bin/dc_prep safetrust` completed setup but did **not** produce `tests/results/dc-prep-timings.json`.
- No Karate feature existed to validate dc_prep phase durations.
- No machine-readable baseline existed to detect setup time regressions across branches or contributor environments.

### Evidence After Solution

1. Run local setup:
   ```bash
   bin/dc_prep safetrust
   cat tests/results/dc-prep-timings.json
   ```
   Expected: JSON file with all seven keys (`docker_up`, `hasura_health`, `metadata_deploy_safetrust`, `migrations_safetrust`, `metadata_reload`, `seeds_safetrust`, `total`).

<img width="757" height="698" alt="Screenshot 2026-06-21 at 1 39 05 PM" src="https://github.com/user-attachments/assets/e7396c6c-0616-451f-890b-1a796cced279" />
<img width="763" height="192" alt="Screenshot 2026-06-21 at 1 40 27 PM" src="https://github.com/user-attachments/assets/4ec812b0-0a17-4a6f-b036-4b838bada8dc" />

2. Run Karate timing feature only:
```bash
  docker compose -f docker-compose-test.yml run --rm karate \
  java -cp /app/tests/karate.jar:/app/tests/postgresql-jdbc.jar:/app/tests/karate/src/test/resources \
  com.intuit.karate.Main \
  --configdir /app/tests/karate/src/test/resources \
  tests/karate/features/dc-prep-timings.feature
```
   Expected: all 3 scenarios pass.

<img width="1666" height="1003" alt="Screenshot 2026-06-21 at 1 50 46 PM" src="https://github.com/user-attachments/assets/2cc3f5a5-0050-43bb-909b-cb1aadf41d5d" />


3. Example timing output observed locally:
   ```json
   {
     "docker_up": 1,
     "hasura_health": 1,
     "metadata_deploy_safetrust": 2,
     "migrations_safetrust": 3,
     "metadata_reload": 4,
     "seeds_safetrust": 5,
     "total": 5
   }
   ```
   (Values vary by machine; all were under the 120s per-phase threshold.)

## 📂 Related Issue

Closes #399 

---

🎉 Thank you for reviewing this PR! 🎉
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timing metrics are now automatically collected during SafeTrust deployments, tracking key operational phases from container startup through seed completion. Results are recorded for analysis and performance monitoring.

* **Tests**
  * Added test suite to validate timing metrics reports, verifying all expected phases are present and confirming performance thresholds are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->