### PR TITLE
fix: standardize auth middleware 401 response shape

### DIFF
--- a/tests/karate/features/auth/sync-user.feature
+++ b/tests/karate/features/auth/sync-user.feature
@@ -50,4 +50,5 @@ Feature: POST /api/auth/sync-user
     Given path '/api/auth/sync-user'
     When method POST
     Then status 401
-    And match response.error == 'Unauthorized: No token provided'
+    And match response.error == 'Unauthorized'
+    And match response.message == 'Missing or malformed Authorization header'

--- a/webhook/src/middleware/auth.js
+++ b/webhook/src/middleware/auth.js
@@ -14,13 +14,19 @@ const authenticateFirebase = async (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return res.status(401).json({ error: 'Unauthorized: No token provided' });
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Missing or malformed Authorization header',
+    });
   }
 
   const idToken = authHeader.slice(7).trim();
 
   if (!idToken) {
-    return res.status(401).json({ error: 'Unauthorized: No token provided' });
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Missing or malformed Authorization header',
+    });
   }
 
   // Bypass for testing
@@ -55,7 +61,10 @@ const authenticateFirebase = async (req, res, next) => {
     return next();
   } catch (error) {
     console.error('Error verifying Firebase ID token:', error.message);
-    return res.status(401).json({ error: 'Unauthorized: Invalid token' });
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Invalid or expired token',
+    });
   }
 };
 


### PR DESCRIPTION
Closes  #401 

## Description

This PR standardizes the `401 Unauthorized` response contract in the webhook Firebase authentication middleware to match the expected response shape used by the Karate integration tests.

### Changes

#### `webhook/src/middleware/auth.js`

Updated unauthorized responses to return a consistent JSON structure:

**Missing or malformed Authorization header**

```json
{
  "error": "Unauthorized",
  "message": "Missing or malformed Authorization header"
}
```

**Invalid or expired token**

```json
{
  "error": "Unauthorized",
  "message": "Invalid or expired token"
}
```

#### `tests/karate/features/auth/sync-user.feature`

Updated the auth-related assertion to validate the new standardized response contract (`error` + `message`) instead of the previous single-string error response.

### Why

The Karate middleware tests expect all authentication failures to return a consistent response shape:

```json
{
  "error": "Unauthorized",
  "message": "<reason>"
}
```

The middleware previously returned string-based error messages such as:

```json
{
  "error": "Unauthorized: No token provided"
}
```

which caused the auth middleware feature tests to fail.

### Verification

```bash
docker compose -f docker-compose-test.yml run --rm karate
```

#### Auth Test Results

* ✅ `middleware.feature` — 4/4 scenarios passed
* ✅ `sync-user.feature` — 3/3 scenarios passed

### Scope

* No authentication logic changes
* No route changes
* No frontend changes
* No behavioral changes for valid tokens

This PR only standardizes the shape of `401 Unauthorized` responses and aligns dependent auth tests with the updated contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication error responses with separate error and message fields
  * Enhanced error messages for authentication failures, providing specific feedback for missing headers, missing tokens, and invalid/expired tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->