### PR TITLE
 🧪[test] GET /api/auth/me - Karate tests

### DIFF
--- a/tests/karate/features/auth/roles.feature
+++ b/tests/karate/features/auth/roles.feature
@@ -29,12 +29,12 @@ Feature: GET /api/auth/me — role-based redirect behavior
     And header x-test-uid = hostUid
     When method GET
     Then status 200
-    And match response.user.roles contains 'host'
+    And match response.user.roles == ['host']
     And match response.redirect == '/dashboard/escrow-dashboard'
 
   Scenario: Host role is stored correctly in user_roles table
-    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'host-user-001'")
-    Then match rows[0].name == 'host'
+    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'host-user-001' ORDER BY r.name")
+    Then match rows == [{ name: 'host' }]
 
   # ── Guest ─
 
@@ -44,12 +44,12 @@ Feature: GET /api/auth/me — role-based redirect behavior
     And header x-test-uid = guestUid
     When method GET
     Then status 200
-    And match response.user.roles contains 'guest'
+    And match response.user.roles == ['guest']
     And match response.redirect == '/dashboard/guest'
 
   Scenario: Guest role is stored correctly in user_roles table
-    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'guest-user-001'")
-    Then match rows[0].name == 'guest'
+    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'guest-user-001' ORDER BY r.name")
+    Then match rows == [{ name: 'guest' }]
 
   # ── Admin ─
 
@@ -59,12 +59,12 @@ Feature: GET /api/auth/me — role-based redirect behavior
     And header x-test-uid = adminUid
     When method GET
     Then status 200
-    And match response.user.roles contains 'admin'
+    And match response.user.roles == ['admin']
     And match response.redirect == '/dashboard/escrow-dashboard'
 
   Scenario: Admin role is stored correctly in user_roles table
-    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'admin-user-001'")
-    Then match rows[0].name == 'admin'
+    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'admin-user-001' ORDER BY r.name")
+    Then match rows == [{ name: 'admin' }]
 
   # ── No role ─
 

--- a/tests/karate/features/auth/roles.feature
+++ b/tests/karate/features/auth/roles.feature
@@ -1,0 +1,99 @@
+Feature: GET /api/auth/me — role-based redirect behavior
+
+  Background:
+    * url webhookUrl
+    * def hostUid   = 'host-user-001'
+    * def guestUid  = 'guest-user-001'
+    * def adminUid  = 'admin-user-001'
+    * def hostToken  = karate.call('classpath:helpers/get-firebase-token.js', { uid: hostUid })
+    * def guestToken = karate.call('classpath:helpers/get-firebase-token.js', { uid: guestUid })
+    * def adminToken = karate.call('classpath:helpers/get-firebase-token.js', { uid: adminUid })
+
+    # Clean and seed users
+    * db.execute("DELETE FROM public.user_roles WHERE user_id IN ('host-user-001','guest-user-001','admin-user-001')")
+    * db.execute("DELETE FROM public.users WHERE id IN ('host-user-001','guest-user-001','admin-user-001')")
+    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('host-user-001',  'host-user-001',  'host@safetrust.cr')  ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('guest-user-001', 'guest-user-001', 'guest@safetrust.cr') ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('admin-user-001', 'admin-user-001', 'admin@safetrust.cr') ON CONFLICT DO NOTHING")
+
+    # Assign roles
+    * db.execute("INSERT INTO public.user_roles (user_id, role_id) SELECT 'host-user-001',  id FROM public.roles WHERE name = 'host'  ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO public.user_roles (user_id, role_id) SELECT 'guest-user-001', id FROM public.roles WHERE name = 'guest' ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO public.user_roles (user_id, role_id) SELECT 'admin-user-001', id FROM public.roles WHERE name = 'admin' ON CONFLICT DO NOTHING")
+
+  # ── Host ──
+
+  Scenario: Host user receives redirect to escrow-dashboard
+    Given path '/api/auth/me'
+    And header Authorization = 'Bearer ' + hostToken
+    And header x-test-uid = hostUid
+    When method GET
+    Then status 200
+    And match response.user.roles contains 'host'
+    And match response.redirect == '/dashboard/escrow-dashboard'
+
+  Scenario: Host role is stored correctly in user_roles table
+    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'host-user-001'")
+    Then match rows[0].name == 'host'
+
+  # ── Guest ─
+
+  Scenario: Guest user receives redirect to guest dashboard
+    Given path '/api/auth/me'
+    And header Authorization = 'Bearer ' + guestToken
+    And header x-test-uid = guestUid
+    When method GET
+    Then status 200
+    And match response.user.roles contains 'guest'
+    And match response.redirect == '/dashboard/guest'
+
+  Scenario: Guest role is stored correctly in user_roles table
+    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'guest-user-001'")
+    Then match rows[0].name == 'guest'
+
+  # ── Admin ─
+
+  Scenario: Admin user receives redirect to escrow-dashboard
+    Given path '/api/auth/me'
+    And header Authorization = 'Bearer ' + adminToken
+    And header x-test-uid = adminUid
+    When method GET
+    Then status 200
+    And match response.user.roles contains 'admin'
+    And match response.redirect == '/dashboard/escrow-dashboard'
+
+  Scenario: Admin role is stored correctly in user_roles table
+    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'admin-user-001'")
+    Then match rows[0].name == 'admin'
+
+  # ── No role ─
+
+  Scenario: User with no role assigned defaults to guest redirect
+    * def noRoleUid = 'no-role-user-001'
+    * def noRoleToken = karate.call('classpath:helpers/get-firebase-token.js', { uid: noRoleUid })
+    * db.execute("DELETE FROM public.users WHERE id = 'no-role-user-001'")
+    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('no-role-user-001', 'no-role-user-001', 'norole@safetrust.cr') ON CONFLICT DO NOTHING")
+    Given path '/api/auth/me'
+    And header Authorization = 'Bearer ' + noRoleToken
+    And header x-test-uid = noRoleUid
+    When method GET
+    Then status 200
+    And match response.user.roles == []
+    And match response.redirect == '/dashboard/guest'
+
+  # ── Unauthenticated ─
+
+  Scenario: No token returns 401
+    Given path '/api/auth/me'
+    When method GET
+    Then status 401
+    And match response.error == 'Unauthorized'
+    And match response.message == 'Missing or malformed Authorization header'
+
+  Scenario: Invalid token returns 401
+    Given path '/api/auth/me'
+    And header Authorization = 'Bearer invalid.token.here'
+    When method GET
+    Then status 401
+    And match response.error == 'Unauthorized'
+    And match response.message == 'Invalid or expired token'

--- a/tests/karate/fixtures/seed-test-users.sql
+++ b/tests/karate/fixtures/seed-test-users.sql
@@ -1,7 +1,10 @@
 -- Seed test users
-DELETE FROM public.users WHERE id IN ('owner-123', 'tenant-456', 'other-user');
+DELETE FROM public.users WHERE id IN ('owner-123', 'tenant-456', 'other-user', 'host-user-001', 'guest-user-001', 'admin-user-001');
 
 INSERT INTO public.users (id, email, last_seen, firebase_uid) VALUES
 ('owner-123', 'owner@example.com', NOW(), 'owner-123'),
 ('tenant-456', 'tenant@example.com', NOW(), 'tenant-456'),
-('other-user', 'other@example.com', NOW(), 'other-user');
+('other-user', 'other@example.com', NOW(), 'other-user'),
+('host-user-001', 'host@safetrust.cr', NOW(), 'host-user-001'),
+('guest-user-001', 'guest@safetrust.cr', NOW(), 'guest-user-001'),
+('admin-user-001', 'admin@safetrust.cr', NOW(), 'admin-user-001');


### PR DESCRIPTION
Closes #408 

## Description:

Adds an authenticated endpoint that reads public.user_roles and returns the user’s roles plus a dashboard redirect path.

## Summary
Adds webhook/src/routes/auth/me.handler.js to query user_roles joined with roles
Registers GET /api/auth/me in the auth router (protected by existing Firebase auth middleware)
Returns { user: { id, email, roles }, redirect } with mapping:
host / admin → /dashboard/escrow-dashboard
guest / no role → /dashboard/guest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new Karate feature spec covering `GET /api/auth/me` role-based dashboard redirects.
  * Verifies host/guest/admin users receive the expected single role and redirect path, including persistence of role mappings.
  * Covers users without role mappings and unauthenticated/invalid-token requests returning the expected error responses.
* **Chores**
  * Expanded the test user seed fixture with additional role-specific accounts for the new scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->