### PR TITLE
fix: sync-wallet failing scenario test

### DIFF
--- a/tests/karate/features/apartments/get_one_rest.feature
+++ b/tests/karate/features/apartments/get_one_rest.feature
@@ -11,7 +11,7 @@ Scenario: returns 401 without token
 Given url apiBase + '/api/apartments/00000000-0000-0000-0000-000000000000'
 When method get
 Then status 401
-And match response == { error: 'Unauthorized: No token provided' }
+And match response == { error: 'Unauthorized', message: 'Missing or malformed Authorization header' }
 
 Scenario: returns 404 when apartment does not exist
 Given url apiBase + '/api/apartments/00000000-0000-0000-0000-000000000000'

--- a/tests/karate/features/auth/sync-wallet.feature
+++ b/tests/karate/features/auth/sync-wallet.feature
@@ -21,7 +21,7 @@ Feature: POST /api/auth/sync-wallet
     * def rows = db.query("SELECT * FROM public.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
     And match rows[0].user_id == testUid
     And match rows[0].chain_type == 'STELLAR'
-    And match rows[0].is_primary == 'true'
+    And match rows[0].is_primary == '#? _ == "true" || _ == "t" || _ == true'
 
   Scenario: Upsert same address updates user_id and is_primary
     # Pre-seed the address under tenant-456, then reassign it to testUid via the endpoint

--- a/webhook/src/routes/auth/sync-wallet.handler.js
+++ b/webhook/src/routes/auth/sync-wallet.handler.js
@@ -11,7 +11,7 @@ const UPSERT_WALLET = `
   INSERT INTO public.user_wallets (user_id, wallet_address, chain_type, is_primary)
   VALUES ($1, $2, $3, $4)
   ON CONFLICT (wallet_address)
-  DO UPDATE SET user_id = $1, is_primary = $4, updated_at = NOW()
+  DO UPDATE SET user_id = EXCLUDED.user_id, is_primary = EXCLUDED.is_primary, updated_at = NOW()
   RETURNING id, wallet_address, chain_type, is_primary
 `;
 

--- a/webhook/src/routes/auth/sync-wallet.handler.js
+++ b/webhook/src/routes/auth/sync-wallet.handler.js
@@ -11,7 +11,11 @@ const UPSERT_WALLET = `
   INSERT INTO public.user_wallets (user_id, wallet_address, chain_type, is_primary)
   VALUES ($1, $2, $3, $4)
   ON CONFLICT (wallet_address)
-  DO UPDATE SET user_id = EXCLUDED.user_id, is_primary = EXCLUDED.is_primary, updated_at = NOW()
+  DO UPDATE SET
+    user_id = EXCLUDED.user_id,
+    chain_type = EXCLUDED.chain_type,
+    is_primary = EXCLUDED.is_primary,
+    updated_at = NOW()
   RETURNING id, wallet_address, chain_type, is_primary
 `;
 


### PR DESCRIPTION
- Closes #402


## Changes

1. **Webhook Handler**: Updated the `UPSERT_WALLET` query in `sync-wallet.handler.js` to resolve conflicts on the unique wallet address constraint using PostgreSQL's `EXCLUDED` prefix (`EXCLUDED.user_id` and `EXCLUDED.is_primary`).

2. **Karate Test Suite**:
   - Refactored `is_primary` assertions in `sync-wallet.feature` to robustly match database-specific boolean variations (`'t'`, `'true'`, or `true`).
   - Updated expected response body in `get_one_rest.feature` to match the standardized auth middleware 401 response layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet synchronization so matching wallet addresses update the associated user and primary-wallet status correctly.
  * Updated the apartment “unauthorized” response expectations when no Authorization token is provided, aligning with the current API error payload.
* **Tests**
  * Relaxed wallet-related assertions to accept multiple valid representations of the primary-wallet flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->