### PR TITLE
feat: add GET /api/auth/me endpoint for role-based routing (#409)

### DIFF
--- a/webhook/src/routes/auth/me.handler.js
+++ b/webhook/src/routes/auth/me.handler.js
@@ -1,0 +1,33 @@
+const db = require('../../services/db');
+
+const meHandler = async (req, res) => {
+  const uid = req.user.uid;   // set by auth.middleware.js
+  const email = req.user.email;
+
+  try {
+    const result = await db.query(
+      `SELECT r.name
+       FROM public.user_roles ur
+       JOIN public.roles r ON r.id = ur.role_id
+       WHERE ur.user_id = $1`,
+      [uid]
+    );
+
+    const roles = result.rows.map((row) => row.name);
+    const isHost = roles.some((r) => ['host', 'admin'].includes(r));
+
+    return res.status(200).json({
+      user: {
+        id: uid,
+        email,
+        roles,
+      },
+      redirect: isHost ? '/dashboard/escrow-dashboard' : '/dashboard/guest',
+    });
+  } catch (error) {
+    console.error('[auth/me] ❌ error:', error.message);
+    return res.status(500).json({ error: 'Failed to resolve user roles' });
+  }
+};
+
+module.exports = { meHandler };

--- a/webhook/src/routes/auth/me.route.js
+++ b/webhook/src/routes/auth/me.route.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { authMiddleware } = require('../../middleware/auth.middleware');
+const { meHandler } = require('./me.handler');
+
+const router = express.Router();
+
+router.get('/api/auth/me', authMiddleware, meHandler);
+
+module.exports = router;

--- a/webhook/src/routes/index.js
+++ b/webhook/src/routes/index.js
@@ -7,10 +7,12 @@ const authRoutes = require('./auth')
 const bidRequestRoutes = require('./bid-requests')
 const reconciliationRoutes = require('./reconciliation')
 const apartmentsRoutes = require('./apartments/list.route');
+const meRoute = require('./auth/me.route');
 
 router.get('/health', (req, res) => res.status(200).send('OK'))
 router.use('/api', authenticateFirebase)
 router.use('/api/auth', authRoutes)
+router.use(meRoute);
 router.use('/api/apartments', apartmentsRoutes);
 router.use('/api/bid-requests', bidRequestRoutes)
 router.use('/api/reconciliation', reconciliationRoutes)


### PR DESCRIPTION
Closes #409 

# Description
This PR resolves issue #409 by adding a new `GET /api/auth/me` endpoint. Previously, `POST /api/auth/sync-user` did not return role information, preventing the frontend from performing role-based routing between the host control tower and guest views.

This new endpoint uses the existing `authMiddleware` to verify the Firebase token, queries the `public.user_roles` join table, and returns both the role information and the appropriate redirect path for the frontend to consume.

### Changes Made
- **Created** `webhook/src/routes/auth/me.handler.js` to handle role querying and redirect logic.
- **Created** `webhook/src/routes/auth/me.route.js` to define the protected endpoint.
- **Updated** `webhook/src/routes/index.js` to register the new `meRoute`.

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- [x] Verified route registration within the Express app.
- [x] Checked logic mapping for `host`, `admin`, and `guest` roles to ensure accurate redirect paths (`/dashboard/escrow-dashboard` vs `/dashboard/guest`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new authenticated `GET /api/auth/me` endpoint that returns the current user’s id/email, role names, and a role-based dashboard redirect path (`/dashboard/escrow-dashboard` for host/admin roles; otherwise `/dashboard/guest`).

* **Bug Fixes**
  * Improved robustness of the user role resolution flow by returning a consistent `500` response with an error message when role lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->