### PR TITLE
feat: add seed-test-escrows.sql fixture for Karate tests

### DIFF
--- a/tests/karate/fixtures/seed-test-escrows.sql
+++ b/tests/karate/fixtures/seed-test-escrows.sql
@@ -1,0 +1,163 @@
+-- seed-test-escrows.sql
+-- Test fixture for public.trustless_work_escrows
+-- Aligned with migration: 1731909059420_create_trustless_work_escrows/up.sql
+--
+-- Valid statuses (CHECK constraint):
+--   'created', 'pending_funding', 'funded', 'active',
+--   'milestone_approved', 'completed', 'disputed', 'resolved', 'cancelled'
+--
+-- Valid escrow_type (CHECK constraint):
+--   'single_release', 'multi_release'
+--
+-- Dependency: seed-test-users.sql must run first
+
+DELETE FROM public.trustless_work_escrows
+WHERE contract_id IN (
+  'escrow-created-001',
+  'escrow-pending-001',
+  'escrow-funded-001',
+  'escrow-disputed-001',
+  'escrow-completed-001'
+);
+
+-- status: created
+-- Used by: initialize.feature (duplicate contract_id test), fund.feature
+INSERT INTO public.trustless_work_escrows (
+  contract_id,
+  marker,
+  approver,
+  releaser,
+  escrow_type,
+  status,
+  amount,
+  balance,
+  asset_code,
+  tenant_id,
+  escrow_metadata
+) VALUES (
+  'escrow-created-001',
+  'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
+  'GAPPROVER111WALLETADDRESS111111111111111111111111111111111',
+  'GRELEASER111WALLETADDRESS111111111111111111111111111111111',
+  'single_release',
+  'created',
+  2500.00,
+  0.00,
+  'USDC',
+  'safetrust',
+  '{"unsigned_transaction": "MOCK_UNSIGNED_XDR_CREATED"}'
+);
+
+-- status: pending_funding
+-- Used by: fund handler pre-condition tests
+INSERT INTO public.trustless_work_escrows (
+  contract_id,
+  marker,
+  approver,
+  releaser,
+  escrow_type,
+  status,
+  amount,
+  balance,
+  asset_code,
+  tenant_id,
+  escrow_metadata
+) VALUES (
+  'escrow-pending-001',
+  'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
+  'GAPPROVER111WALLETADDRESS111111111111111111111111111111111',
+  'GRELEASER111WALLETADDRESS111111111111111111111111111111111',
+  'single_release',
+  'pending_funding',
+  1800.00,
+  0.00,
+  'USDC',
+  'safetrust',
+  '{"unsigned_transaction": "MOCK_UNSIGNED_XDR_PENDING"}'
+);
+
+-- status: funded
+-- Used by: milestone approval tests, reconciliation sync tests
+INSERT INTO public.trustless_work_escrows (
+  contract_id,
+  marker,
+  approver,
+  releaser,
+  escrow_type,
+  status,
+  amount,
+  balance,
+  asset_code,
+  tenant_id,
+  escrow_metadata
+) VALUES (
+  'escrow-funded-001',
+  'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
+  'GAPPROVER111WALLETADDRESS111111111111111111111111111111111',
+  'GRELEASER111WALLETADDRESS111111111111111111111111111111111',
+  'single_release',
+  'funded',
+  3200.00,
+  3200.00,
+  'USDC',
+  'safetrust',
+  '{"unsigned_transaction": "MOCK_UNSIGNED_XDR_FUNDED"}'
+);
+
+-- status: disputed
+-- Used by: open_dispute.feature, resolve dispute tests
+INSERT INTO public.trustless_work_escrows (
+  contract_id,
+  marker,
+  approver,
+  releaser,
+  resolver,
+  escrow_type,
+  status,
+  amount,
+  balance,
+  asset_code,
+  tenant_id,
+  escrow_metadata
+) VALUES (
+  'escrow-disputed-001',
+  'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
+  'GAPPROVER111WALLETADDRESS111111111111111111111111111111111',
+  'GRELEASER111WALLETADDRESS111111111111111111111111111111111',
+  'GRESOLVER111WALLETADDRESS111111111111111111111111111111111',
+  'single_release',
+  'disputed',
+  2100.00,
+  2100.00,
+  'USDC',
+  'safetrust',
+  '{"unsigned_transaction": "MOCK_UNSIGNED_XDR_DISPUTED"}'
+);
+
+-- status: completed
+-- Used by: sync-escrows.feature, reconciliation tests
+INSERT INTO public.trustless_work_escrows (
+  contract_id,
+  marker,
+  approver,
+  releaser,
+  escrow_type,
+  status,
+  amount,
+  balance,
+  asset_code,
+  tenant_id,
+  escrow_metadata
+) VALUES (
+  'escrow-completed-001',
+  'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
+  'GAPPROVER111WALLETADDRESS111111111111111111111111111111111',
+  'GRELEASER111WALLETADDRESS111111111111111111111111111111111',
+  'single_release',
+  'completed',
+  2800.00,
+  0.00,
+  'USDC',
+  'safetrust',
+  '{"unsigned_transaction": "MOCK_UNSIGNED_XDR_COMPLETED"}'
+);


### PR DESCRIPTION
closes #410 

## Description
This PR introduces a new SQL fixture file, `seed-test-escrows.sql`, to provide canonical escrow records for Karate tests. This addresses issue #410 by eliminating the need for duplicate inline SQL across various feature files (fund callback, initialize callback, dispute, etc.).

## Changes
- Created `tests/karate/fixtures/seed-test-escrows.sql`.
- Added idempotent seed logic (DELETE followed by INSERT) for five canonical escrow states:
  - `created`
  - `pending_funding`
  - `funded`
  - `disputed`
  - `completed`
- Aligned data structure with migration `1731909059420_create_trustless_work_escrows`.

## Impacted Tests
- `tests/karate/features/escrows/fund.feature`
- `tests/karate/features/escrows/initialize.feature`
- `tests/karate/features/reconciliation/sync-escrows.feature`
- Dispute and milestone approval tests.

## Verification
- [x] Verified SQL schema against `migrations/safetrust/1731909059420_create_trustless_work_escrows/up.sql`.
- [x] Confirmed table constraints for `status` and `escrow_type` are respected.

## Related Issues
Fixes #410