### PR TITLE
test: add Karate integration tests for POST /api/escrows/resolve-dispute

### DIFF
--- a/tests/karate/features/escrows/resolve-dispute.feature
+++ b/tests/karate/features/escrows/resolve-dispute.feature
@@ -1,0 +1,54 @@
+Feature: POST /api/escrows/resolve-dispute — TrustlessWork dispute resolution callback
+
+  Background:
+    * url webhookUrl
+    * db.execute(karate.read('file:tests/karate/fixtures/seed-test-users.sql'))
+    * db.execute(karate.read('file:tests/karate/fixtures/seed-test-escrows.sql'))
+
+  Scenario: Valid resolve callback updates status to resolved and zeroes balance
+    Given path '/api/escrows/resolve-dispute'
+    And header Content-Type = 'application/json'
+    And request
+    """
+    {
+      "contractId": "escrow-disputed-001",
+      "resolver": "GRESOLVER111WALLETADDRESS111111111111111111111111111111111",
+      "resolutionNote": "Resolved in favor of host"
+    }
+    """
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
+    And match rows[0].status == 'resolved'
+    And match rows[0].balance == '0E-7'
+
+  Scenario: Missing contractId returns 400
+    Given path '/api/escrows/resolve-dispute'
+    And header Content-Type = 'application/json'
+    And request { "resolver": "GRESOLVER111WALLETADDRESS111111111111111111111111111111111" }
+    When method POST
+    Then status 400
+    And match response.error == 'Missing required fields: contractId, resolver'
+
+  Scenario: Missing resolver returns 400
+    Given path '/api/escrows/resolve-dispute'
+    And header Content-Type = 'application/json'
+    And request { "contractId": "escrow-disputed-001" }
+    When method POST
+    Then status 400
+    And match response.error == 'Missing required fields: contractId, resolver'
+
+  Scenario: Unknown contractId returns 404
+    Given path '/api/escrows/resolve-dispute'
+    And header Content-Type = 'application/json'
+    And request
+    """
+    {
+      "contractId": "non-existent-xyz",
+      "resolver": "GRESOLVER111WALLETADDRESS111111111111111111111111111111111"
+    }
+    """
+    When method POST
+    Then status 404
+    And match response.error contains 'Escrow not found'

--- a/tests/karate/features/escrows/resolve-dispute.feature
+++ b/tests/karate/features/escrows/resolve-dispute.feature
@@ -19,9 +19,9 @@ Feature: POST /api/escrows/resolve-dispute — TrustlessWork dispute resolution 
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, (balance = 0::numeric) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
     And match rows[0].status == 'resolved'
-    And match rows[0].balance_is_zero == 'true'
+    And match rows[0].balance_is_zero == '1'
 
   Scenario: Missing contractId returns 400
     Given path '/api/escrows/resolve-dispute'

--- a/tests/karate/features/escrows/resolve-dispute.feature
+++ b/tests/karate/features/escrows/resolve-dispute.feature
@@ -19,9 +19,9 @@ Feature: POST /api/escrows/resolve-dispute — TrustlessWork dispute resolution 
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
+    * def rows = db.query("SELECT status, (balance = 0::numeric) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
     And match rows[0].status == 'resolved'
-    And match rows[0].balance == '0E-7'
+    And match rows[0].balance_is_zero == 'true'
 
   Scenario: Missing contractId returns 400
     Given path '/api/escrows/resolve-dispute'

--- a/tests/karate/fixtures/seed-test-escrows.sql
+++ b/tests/karate/fixtures/seed-test-escrows.sql
@@ -1,0 +1,23 @@
+-- Seed test escrows for dispute resolution tests
+DELETE FROM public.trustless_work_escrows WHERE contract_id IN ('escrow-disputed-001');
+INSERT INTO public.trustless_work_escrows (
+    contract_id,
+    marker,
+    approver,
+    releaser,
+    escrow_type,
+    status,
+    asset_code,
+    amount,
+    balance
+) VALUES (
+    'escrow-disputed-001',
+    'GMARKERHOTELWALLET11111111111111111111111111111111111',
+    'GAPPROVERGUESTWALLET111111111111111111111111111111111',
+    'GRELEASERPLATFORMWALLET1111111111111111111111111111111',
+    'single_release',
+    'disputed',
+    'USDC',
+    100.0000000,
+    50.0000000
+);

--- a/tests/karate/fixtures/seed-test-escrows.sql
+++ b/tests/karate/fixtures/seed-test-escrows.sql
@@ -50,10 +50,6 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: pending_funding
 -- Used by: fund handler pre-condition tests
--- Seed test escrows for Trustless Work
-DELETE FROM public.escrow_milestones WHERE milestone_id = 'check_in';
-DELETE FROM public.trustless_work_escrows WHERE contract_id IN ('escrow-funded-001', 'escrow-pending-002');
-
 INSERT INTO public.trustless_work_escrows (
   contract_id,
   marker,


### PR DESCRIPTION
## Summary

This PR adds Karate integration tests for the \POST /api/escrows/resolve-dispute\ endpoint, covering the TrustlessWork dispute resolution callback flow as specified in issue #422.

## Test Scenarios

| Scenario | Expected Result |
|---|---|
| Valid resolve callback | \200 { received: true }\, DB row updated to \status: resolved\, \alance: 0\ |
| Missing \contractId\ | \400\ with \Missing required fields: contractId, resolver\ |
| Missing \esolver\ | \400\ with \Missing required fields: contractId, resolver\ |
| Unknown \contractId\ | \404\ with \Escrow not found\ error |

## Dependencies

This test relies on:
- \	ests/karate/fixtures/seed-test-escrows.sql\ (tracked in #410) — provides \escrow-disputed-001\ record
- \webhook/src/routes/escrows/resolve-dispute.handler.js\ — endpoint handler implementation

## Testing

\\\ash
docker compose -f docker-compose-test.yml run --rm --build karate
\\\

Closes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for dispute resolution via `POST /api/escrows/resolve-dispute`.
  * Verifies a valid callback returns success, marks the escrow as `resolved`, and sets the balance to zero.
  * Confirms deterministic `400` validation errors when `contractId` or `resolver` is missing.
  * Confirms a `404` error for unknown escrow records.
  * Updated test escrow seeding data to match the new fixture shape and metadata expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->