### PR TITLE
chore(seeds): add trustless_work_escrows and escrow_milestones seed rows aligned with existing webhook_events seed contract IDs

### DIFF
--- a/seeds/safetrust/1776200000000_trustless_work_escrows_seed.sql
+++ b/seeds/safetrust/1776200000000_trustless_work_escrows_seed.sql
@@ -1,0 +1,71 @@
+-- Seeds trustless_work_escrows and escrow_milestones
+-- Uses contract IDs matching _trustless_work_webhook_events.sql
+-- Safe to re-run: DELETE guards on all inserts
+
+DELETE FROM public.escrow_milestones
+  WHERE escrow_id IN (
+    SELECT id FROM public.trustless_work_escrows
+    WHERE contract_id IN (
+      'CAATN5DTEST00001','CAATN5DTEST00002','CAATN5DTEST00003'
+    )
+  );
+
+DELETE FROM public.trustless_work_escrows
+  WHERE contract_id IN (
+    'CAATN5DTEST00001','CAATN5DTEST00002','CAATN5DTEST00003'
+  );
+
+-- Contract 1: milestone_approved (matches escrow.created + milestone.approved events)
+INSERT INTO public.trustless_work_escrows (
+  contract_id, marker, approver, releaser,
+  escrow_type, status, asset_code, amount, balance, tenant_id
+) VALUES (
+  'CAATN5DTEST00001',
+  'GAWVVSATEST0001PROVIDER',
+  'GAWVVSATEST0001APPROVER',
+  'GAWVVSATEST0001RELEASER',
+  'single_release', 'milestone_approved',
+  'USDC', 150.00, 150.00, 'safetrust'
+);
+
+-- Contract 2: funded (matches escrow.funded event)
+INSERT INTO public.trustless_work_escrows (
+  contract_id, marker, approver, releaser,
+  escrow_type, status, asset_code, amount, balance, tenant_id
+) VALUES (
+  'CAATN5DTEST00002',
+  'GAWVVSATEST0002PROVIDER',
+  'GAWVVSATEST0002APPROVER',
+  'GAWVVSATEST0002RELEASER',
+  'single_release', 'funded',
+  'USDC', 300.00, 300.00, 'safetrust'
+);
+
+-- Contract 3: completed (matches escrow.completed + escrow.cancelled events)
+INSERT INTO public.trustless_work_escrows (
+  contract_id, marker, approver, releaser,
+  escrow_type, status, asset_code, amount, balance, tenant_id
+) VALUES (
+  'CAATN5DTEST00003',
+  'GAWVVSATEST0003PROVIDER',
+  'GAWVVSATEST0003APPROVER',
+  'GAWVVSATEST0003RELEASER',
+  'single_release', 'completed',
+  'USDC', 200.00, 0.00, 'safetrust'
+);
+
+-- Milestone for CAATN5DTEST00001 (status: milestone_approved)
+INSERT INTO public.escrow_milestones (
+  escrow_id, milestone_id, description,
+  amount, status, approved_by, approved_at, tenant_id
+)
+SELECT
+  id, 'check_in',
+  'Check-in milestone for rental period',
+  150.00, 'approved',
+  'GAWVVSATEST0001APPROVER',
+  NOW() - INTERVAL '2 days',
+  'safetrust'
+FROM public.trustless_work_escrows
+WHERE contract_id = 'CAATN5DTEST00001'
+ON CONFLICT (escrow_id, milestone_id) DO NOTHING;


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

## Pull Request Information

Adds the missing local seed data for `trustless_work_escrows` and `escrow_milestones`. This allows the existing webhook fixture contract IDs to resolve during local escrow lifecycle testing.

## Summary of Changes

- Added `seeds/safetrust/1776200000000_trustless_work_escrows_seed.sql`
- Seeded three escrows matching `CAATN5DTEST00001` through `CAATN5DTEST00003`
- Seeded one approved `check_in` milestone for `CAATN5DTEST00001`
- Added FK-safe deletion order and idempotent inserts

## Testing

Static validation confirmed:

- Contract IDs match `_trustless_work_webhook_events.sql`
- Escrow and milestone statuses satisfy schema constraints
- Milestones are deleted before escrows
- Wallet values for `CAATN5DTEST00001` match webhook payloads
- The milestone insert handles conflicts safely

The following require a running local Hasura stack and remain to be verified:

- `dc_prep` completes successfully
- Three escrow rows and one milestone row are inserted
- Fund and approve-milestone endpoints return `{ received: true }`
- Running `dc_prep` twice succeeds

## Related Issue

Closes #437 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seed data for three trustless work escrow records with varied statuses, participants, and USDC amounts.
  * Added an approved “check-in” milestone for one escrow.

* **Chores**
  * Updated seed behavior to safely replace matching escrow records and avoid duplicate milestone entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->