### PR TITLE
fix(webhook/escrows): standardize all Hasura mutation field names to …

### DIFF
--- a/webhook/src/routes/escrows/approve-milestone.handler.js
+++ b/webhook/src/routes/escrows/approve-milestone.handler.js
@@ -56,41 +56,19 @@ async function approveMilestoneHandler(req, res) {
   const approvedAt = new Date().toISOString();
 
   try {
-    // Step 1: Look up the escrow ID. Try camelCase first.
+    // Step 1: Look up the escrow ID using camelCase fields
     let escrowId;
-    let isCustom = true;
 
-    try {
-      const lookupCustom = `
-        query GetEscrowId($contractId: String!) {
-          trustlessWorkEscrows(where: { contractId: { _eq: $contractId } }) {
-            id
-          }
+    const lookupQuery = `
+      query GetEscrowId($contractId: String!) {
+        trustless_work_escrows(where: { contractId: { _eq: $contractId } }) {
+          id
         }
-      `;
-      const data = await postHasura(lookupCustom, { contractId });
-      if (data.trustlessWorkEscrows && data.trustlessWorkEscrows.length > 0) {
-        escrowId = data.trustlessWorkEscrows[0].id;
       }
-    } catch (e) {
-      console.warn('[escrow/approve-milestone] custom lookup failed, trying default fallback...');
-      isCustom = false;
-    }
-
-    if (!escrowId) {
-      // Fallback to snake_case lookup
-      const lookupDefault = `
-        query GetEscrowId($contractId: String!) {
-          trustless_work_escrows(where: { contract_id: { _eq: $contractId } }) {
-            id
-          }
-        }
-      `;
-      const data = await postHasura(lookupDefault, { contractId });
-      if (data.trustless_work_escrows && data.trustless_work_escrows.length > 0) {
-        escrowId = data.trustless_work_escrows[0].id;
-        isCustom = false;
-      }
+    `;
+    const data = await postHasura(lookupQuery, { contractId });
+    if (data.trustless_work_escrows && data.trustless_work_escrows.length > 0) {
+      escrowId = data.trustless_work_escrows[0].id;
     }
 
     if (!escrowId) {
@@ -100,140 +78,71 @@ async function approveMilestoneHandler(req, res) {
     }
 
     // Step 2: Perform the updates using the found escrowId UUID
-    if (isCustom) {
-      const mutationCustomMilestone = `
-        mutation ApproveMilestone(
-          $escrowId: uuid!
-          $milestoneId: String!
-          $approver: String!
-          $approvedAt: timestamptz!
-        ) {
-          update_escrowMilestones(
-            where: {
-              escrowId: { _eq: $escrowId }
-              milestoneId: { _eq: $milestoneId }
-            }
-            _set: {
-              status: "approved"
-              approvedBy: $approver
-              approvedAt: $approvedAt
-              updatedAt: $approvedAt
-            }
-          ) {
-            affected_rows
+    const mutationMilestone = `
+      mutation ApproveMilestone(
+        $escrowId: uuid!
+        $milestoneId: String!
+        $approver: String!
+        $approvedAt: timestamptz!
+      ) {
+        update_escrow_milestones(
+          where: {
+            escrowId: { _eq: $escrowId }
+            milestoneId: { _eq: $milestoneId }
           }
-        }
-      `;
-      const resultMilestone = await postHasura(mutationCustomMilestone, {
-        escrowId,
-        milestoneId,
-        approver,
-        approvedAt
-      });
-      const milestoneRows = resultMilestone.update_escrowMilestones?.affected_rows || 0;
-
-      if (milestoneRows === 0) {
-        return res.status(404).json({
-          error: 'Escrow or milestone not found',
-        });
-      }
-
-      const mutationCustomEscrow = `
-        mutation ApproveEscrow(
-          $escrowId: uuid!
-          $approvedAt: timestamptz!
-        ) {
-          update_trustlessWorkEscrows(
-            where: {
-              id: { _eq: $escrowId }
-            }
-            _set: {
-              status: "milestone_approved"
-              updatedAt: $approvedAt
-            }
-          ) {
-            affected_rows
+          _set: {
+            status: "approved"
+            approvedBy: $approver
+            approvedAt: $approvedAt
+            updatedAt: $approvedAt
           }
-        }
-      `;
-      const resultEscrow = await postHasura(mutationCustomEscrow, {
-        escrowId,
-        approvedAt
-      });
-      const escrowRows = resultEscrow.update_trustlessWorkEscrows?.affected_rows || 0;
-
-      if (escrowRows === 0) {
-        return res.status(404).json({
-          error: 'Escrow or milestone not found',
-        });
-      }
-    } else {
-      const mutationDefaultMilestone = `
-        mutation ApproveMilestone(
-          $escrowId: uuid!
-          $milestoneId: String!
-          $approver: String!
-          $approvedAt: timestamptz!
         ) {
-          update_escrow_milestones(
-            where: {
-              escrow_id: { _eq: $escrowId }
-              milestone_id: { _eq: $milestoneId }
-            }
-            _set: {
-              status: "approved"
-              approved_by: $approver
-              approved_at: $approvedAt
-              updated_at: $approvedAt
-            }
-          ) {
-            affected_rows
-          }
+          affected_rows
         }
-      `;
-      const resultMilestone = await postHasura(mutationDefaultMilestone, {
-        escrowId,
-        milestoneId,
-        approver,
-        approvedAt
-      });
-      const milestoneRows = resultMilestone.update_escrow_milestones?.affected_rows || 0;
-
-      if (milestoneRows === 0) {
-        return res.status(404).json({
-          error: 'Escrow or milestone not found',
-        });
       }
+    `;
+    const resultMilestone = await postHasura(mutationMilestone, {
+      escrowId,
+      milestoneId,
+      approver,
+      approvedAt
+    });
+    const milestoneRows = resultMilestone.update_escrow_milestones?.affected_rows || 0;
 
-      const mutationDefaultEscrow = `
-        mutation ApproveEscrow(
-          $escrowId: uuid!
-          $approvedAt: timestamptz!
+    if (milestoneRows === 0) {
+      return res.status(404).json({
+        error: 'Escrow or milestone not found',
+      });
+    }
+
+    const mutationEscrow = `
+      mutation ApproveEscrow(
+        $escrowId: uuid!
+        $approvedAt: timestamptz!
+      ) {
+        update_trustless_work_escrows(
+          where: {
+            id: { _eq: $escrowId }
+          }
+          _set: {
+            status: "milestone_approved"
+            updatedAt: $approvedAt
+          }
         ) {
-          update_trustless_work_escrows(
-            where: {
-              id: { _eq: $escrowId }
-            }
-            _set: {
-              status: "milestone_approved"
-              updated_at: $approvedAt
-            }
-          ) {
-            affected_rows
-          }
+          affected_rows
         }
-      `;
-      const resultEscrow = await postHasura(mutationDefaultEscrow, {
-        escrowId,
-        approvedAt
-      });
-      const escrowRows = resultEscrow.update_trustless_work_escrows?.affected_rows || 0;
-
-      if (escrowRows === 0) {
-        return res.status(404).json({
-          error: 'Escrow or milestone not found',
-        });
       }
+    `;
+    const resultEscrow = await postHasura(mutationEscrow, {
+      escrowId,
+      approvedAt
+    });
+    const escrowRows = resultEscrow.update_trustless_work_escrows?.affected_rows || 0;
+
+    if (escrowRows === 0) {
+      return res.status(404).json({
+        error: 'Escrow or milestone not found',
+      });
     }
 
     console.log(

--- a/webhook/src/routes/escrows/dispute.handler.js
+++ b/webhook/src/routes/escrows/dispute.handler.js
@@ -16,13 +16,13 @@ const disputeEscrowHandler = async (req, res) => {
   const mutation = `
     mutation DisputeEscrow($contractId: String!) {
       update_trustless_work_escrows(
-        where: { contract_id: { _eq: $contractId } }
+        where: { contractId: { _eq: $contractId } }
         _set: {
           status: "disputed",
-          updated_at: "now()"
+          updatedAt: "now()"
         }
       ) {
-        returning { id contract_id status }
+        returning { id contractId status }
       }
     }
   `;

--- a/webhook/src/routes/escrows/fund.handler.js
+++ b/webhook/src/routes/escrows/fund.handler.js
@@ -19,18 +19,18 @@ const fundEscrowHandler = async (req, res) => {
     mutation FundEscrow($contractId: String!, $amount: numeric!) {
       update_trustless_work_escrows(
         where: {
-          contract_id: { _eq: $contractId },
+          contractId: { _eq: $contractId },
           status: { _in: ["created", "pending_funding"] }
         }
         _set: {
           status: "funded",
           balance: $amount,
-          updated_at: "now()"
+          updatedAt: "now()"
         }
       ) {
         returning {
           id
-          contract_id
+          contractId
           status
           balance
         }

--- a/webhook/src/routes/escrows/initialize.handler.js
+++ b/webhook/src/routes/escrows/initialize.handler.js
@@ -36,9 +36,9 @@ const initializeEscrowHandler = async (req, res) => {
     mutation InitializeEscrow($object: trustless_work_escrows_insert_input!) {
       insert_trustless_work_escrows_one(object: $object) {
         id
-        contract_id
+        contractId
         status
-        created_at
+        createdAt
       }
     }
   `;
@@ -62,24 +62,24 @@ const initializeEscrowHandler = async (req, res) => {
         query: mutation,
         variables: {
           object: {
-            contract_id,
+            contractId: contract_id,
             marker,
             approver,
             releaser,
             resolver: resolver || null,
-            escrow_type,
+            escrowType: escrow_type,
             status: 'created',             // initial status per valid_escrow_status CHECK
-            asset_code: asset_code || 'USDC',
-            asset_issuer: asset_issuer || null,
+            assetCode: asset_code || 'USDC',
+            assetIssuer: asset_issuer || null,
             amount,
             balance: 0,
-            booking_id: booking_id || null,
-            room_id: room_id || null,
-            hotel_id: hotel_id || null,
-            guest_id: guest_id || null,
-            tenant_id: 'safetrust',
-            escrow_metadata: req.body,     // full payload stored as JSONB
-            booking_metadata: booking_metadata || null,
+            bookingId: booking_id || null,
+            roomId: room_id || null,
+            hotelId: hotel_id || null,
+            guestId: guest_id || null,
+            tenantId: 'safetrust',
+            escrowMetadata: req.body,     // full payload stored as JSONB
+            bookingMetadata: booking_metadata || null,
           }
         }
       }),

--- a/webhook/src/routes/escrows/release-funds.handler.js
+++ b/webhook/src/routes/escrows/release-funds.handler.js
@@ -7,10 +7,9 @@ const releaseFundsHandler = async (req, res) => {
     });
   }
 
-  // 1. Custom camelCase mutation (applied when metadata is fully loaded)
-  const mutationCustom = `
+  const mutation = `
     mutation ReleaseFunds($contractId: String!) {
-      update_trustlessWorkEscrows(
+      update_trustless_work_escrows(
         where: { contractId: { _eq: $contractId } }
         _set: {
           status: "completed",
@@ -19,22 +18,6 @@ const releaseFundsHandler = async (req, res) => {
         }
       ) {
         returning { id contractId status balance }
-      }
-    }
-  `;
-
-  // 2. Default snake_case mutation (fallback for default tracked tables)
-  const mutationDefault = `
-    mutation ReleaseFunds($contractId: String!) {
-      update_trustless_work_escrows(
-        where: { contract_id: { _eq: $contractId } }
-        _set: {
-          status: "completed",
-          balance: 0,
-          updated_at: "now()"
-        }
-      ) {
-        returning { id contract_id status balance }
       }
     }
   `;
@@ -48,43 +31,23 @@ const releaseFundsHandler = async (req, res) => {
       return res.status(500).json({ error: 'Server configuration error' });
     }
 
-    // Try custom mutation first
-    let hasuraRes = await fetch(endpoint, {
+    const hasuraRes = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
       },
-      body: JSON.stringify({ query: mutationCustom, variables: { contractId } }),
+      body: JSON.stringify({ query: mutation, variables: { contractId } }),
     });
 
-    let hasuraData = await hasuraRes.json();
-    let updated;
-
+    const hasuraData = await hasuraRes.json();
+    
     if (hasuraData.errors) {
-      console.warn('[escrow/release-funds] Custom mutation failed, trying default mutation fallback...');
-      
-      // Fallback to default mutation
-      hasuraRes = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(adminSecret ? { 'x-hasura-admin-secret': adminSecret } : {}),
-        },
-        body: JSON.stringify({ query: mutationDefault, variables: { contractId } }),
-      });
-      
-      hasuraData = await hasuraRes.json();
-      
-      if (hasuraData.errors) {
-        console.error('[escrow/release-funds] Hasura error (default mutation):', hasuraData.errors);
-        return res.status(500).json({ error: 'Failed to update escrow status', details: hasuraData.errors });
-      }
-      
-      updated = hasuraData.data?.update_trustless_work_escrows?.returning;
-    } else {
-      updated = hasuraData.data?.update_trustlessWorkEscrows?.returning;
+      console.error('[escrow/release-funds] Hasura error:', hasuraData.errors);
+      return res.status(500).json({ error: 'Failed to update escrow status', details: hasuraData.errors });
     }
+    
+    const updated = hasuraData.data?.update_trustless_work_escrows?.returning;
 
     if (!updated || !updated.length) {
       return res.status(404).json({ error: `Escrow not found for contractId: ${contractId}` });

--- a/webhook/src/routes/escrows/resolve-dispute.handler.js
+++ b/webhook/src/routes/escrows/resolve-dispute.handler.js
@@ -13,18 +13,18 @@ const resolveDisputeHandler = async (req, res) => {
     mutation ResolveDispute($contractId: String!) {
       update_trustless_work_escrows(
         where: {
-          contract_id: { _eq: $contractId },
+          contractId: { _eq: $contractId },
           status: { _eq: "disputed" }
         }
         _set: {
           status: "resolved",
           balance: 0,
-          updated_at: "now()"
+          updatedAt: "now()"
         }
       ) {
         returning {
           id
-          contract_id
+          contractId
           status
           balance
         }


### PR DESCRIPTION
## Description
This PR standardizes the Hasura mutation and query field names in the escrow webhook handlers to use `camelCase`. 

The `public_trustless_work_escrows.yaml` and `public_escrow_milestones.yaml` files in Hasura metadata define `custom_name` aliases that expose all fields as `camelCase` in the GraphQL schema. The webhook handlers were incorrectly using `snake_case` fields (or a dual-try fallback pattern), which caused Hasura to return field-not-found errors.

### Changes Made:
* **`initialize.handler.js`**: Updated all `trustless_work_escrows_insert_input` fields to `camelCase` (e.g., `contractId`, `assetCode`, `escrowType`).
* **`fund.handler.js`**: Replaced `contract_id` and `updated_at` with `contractId` and `updatedAt`.
* **`approve-milestone.handler.js`**: Removed the dual-try (`isCustom`) pattern and replaced it with a single, consistent `camelCase` mutation flow.
* **`release-funds.handler.js`**: Removed the dual-try fallback pattern and standardized on the `camelCase` mutation.
* **`dispute.handler.js` & `resolve-dispute.handler.js`**: Updated variables to use `contractId` and `updatedAt`.

Closes #436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved escrow initialization, funding, milestone approval, dispute resolution, and fund release workflows.
  * Updated escrow operations to consistently process records and statuses.
  * Added clearer handling when requested escrow or milestone updates cannot be completed.
  * Improved error handling for escrow release requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->