### PR TITLE
Feat(migration)/add columns apartments table

### DIFF
--- a/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
@@ -42,6 +42,11 @@ select_permissions:
         - available_until
         - created_at
         - updated_at
+        - bathrooms
+        - capacity
+        - max_guests
+        - floor_area
+        - furnished
       filter:
         _or:
           - owner_id:

--- a/migrations/safetrust/1777000000000_add_apartment_capacity_fields/down.sql
+++ b/migrations/safetrust/1777000000000_add_apartment_capacity_fields/down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS public.idx_apartments_furnished;
+DROP INDEX IF EXISTS public.idx_apartments_bathrooms;
+DROP INDEX IF EXISTS public.idx_apartments_capacity;
+
+ALTER TABLE public.apartments
+  DROP CONSTRAINT IF EXISTS valid_max_guests,
+  DROP CONSTRAINT IF EXISTS valid_capacity,
+  DROP CONSTRAINT IF EXISTS valid_bathrooms;
+
+ALTER TABLE public.apartments
+  DROP COLUMN IF EXISTS furnished,
+  DROP COLUMN IF EXISTS floor_area,
+  DROP COLUMN IF EXISTS max_guests,
+  DROP COLUMN IF EXISTS capacity,
+  DROP COLUMN IF EXISTS bathrooms;

--- a/migrations/safetrust/1777000000000_add_apartment_capacity_fields/up.sql
+++ b/migrations/safetrust/1777000000000_add_apartment_capacity_fields/up.sql
@@ -1,0 +1,15 @@
+ALTER TABLE public.apartments
+  ADD COLUMN IF NOT EXISTS bathrooms INTEGER DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS capacity INTEGER DEFAULT 2,
+  ADD COLUMN IF NOT EXISTS max_guests INTEGER DEFAULT 2,
+  ADD COLUMN IF NOT EXISTS floor_area DECIMAL(8,2),
+  ADD COLUMN IF NOT EXISTS furnished BOOLEAN DEFAULT false;
+
+ALTER TABLE public.apartments
+  ADD CONSTRAINT valid_bathrooms CHECK (bathrooms > 0),
+  ADD CONSTRAINT valid_capacity CHECK (capacity > 0),
+  ADD CONSTRAINT valid_max_guests CHECK (max_guests > 0);
+
+CREATE INDEX IF NOT EXISTS idx_apartments_capacity ON public.apartments(capacity);
+CREATE INDEX IF NOT EXISTS idx_apartments_bathrooms ON public.apartments(bathrooms);
+CREATE INDEX IF NOT EXISTS idx_apartments_furnished ON public.apartments(furnished);


### PR DESCRIPTION
 # Pull Request for SafeTrust - 
Close Issue #442 

  ❗ **Pull Request Information**

  Adds five listing metadata columns to the `apartments` table (`bathrooms`,
  `capacity`, `max_guests`, `floor_area`, `furnished`) so the rental search
  experience in `frontend-SafeTrust` can filter and display data that the UI
  already expects but was never persisted. The `ApartmentCard` component in
  `components/rent/` shows "1 ba" and the `FilterSidebar` needs a
  capacity/guests filter — this migration unblocks both.

  ## 🌀 Summary of Changes

  - **New migration `1777000000000_add_apartment_capacity_fields`**:
    adds `bathrooms INTEGER DEFAULT 1`, `capacity INTEGER DEFAULT 2`,
    `max_guests INTEGER DEFAULT 2`, `floor_area DECIMAL(8,2)` (nullable),
    `furnished BOOLEAN DEFAULT false`. Idempotent (`ADD COLUMN IF NOT EXISTS`).
  - **CHECK constraints**: `valid_bathrooms`, `valid_capacity`, `valid_max_guests`
    enforce `> 0` at the DB layer so garbage rows never land regardless of
    API-layer validation.
  - **btree indexes** on `capacity`, `bathrooms`, `furnished` to keep filter
    queries from the frontend fast at scale.
  - **Clean down.sql** that reverses indexes → constraints → columns in
    reverse order, so rollback is safe.
  - **Hasura metadata**: exposes the five new columns to the `user` role's
    `select_permissions` in `public_apartments.yaml`. The `admin` role
    already uses `columns: "*"` and inherits them automatically.
  - **Atomic commits**: schema (up + down) is one commit; metadata is a
    separate commit — either can be reverted independently.

  ### Design decisions worth flagging for the reviewer

  - **`capacity` vs `max_guests` are intentionally distinct**: `capacity`
    is the physical rated occupancy, `max_guests` is the owner-set booking
    limit. The issue calls this out and the UI needs both.
  - **`insert_permissions` / `update_permissions` were NOT modified**.
    Scope of the issue is `select_permissions` only, and it matches the
    precedent set by migration `1775000000000` (which also did not add
    `bedrooms` / `pet_friendly` / `category` to write permissions).
    A separate PR should decide whether owners can write these fields.
  - **Timestamp placement**: `1777000000000` intentionally sorts *before*
    the existing `1777000000001/2/3` search-function migrations per the
    issue spec. Those functions do not reference the new columns, so the
    ordering is safe — flagging it here for transparency.

  ## 🛠 Testing

  ### Evidence Before Solution

  Running the acceptance-criteria query on `main` fails because the
  columns do not exist:

  ```sql
  SELECT bathrooms, capacity, max_guests, floor_area, furnished
  FROM apartments LIMIT 1;
  -- ERROR: column "bathrooms" does not exist

  Evidence After Solution

  After dc_prep applies the migration:

  SELECT bathrooms, capacity, max_guests, floor_area, furnished
  FROM apartments LIMIT 1;
  -- Returns row with bathrooms=1, capacity=2, max_guests=2,
  -- floor_area=NULL, furnished=false for all pre-existing rows.

  Acceptance checklist:

  - [ ] dc_prep applies the migration without errors
  - [ ] SELECT bathrooms, capacity, max_guests, floor_area, furnished FROM apartments LIMIT 1 succeeds
  - [ ] Existing rows show bathrooms=1, capacity=2, max_guests=2,
  furnished=false, floor_area=NULL
  - [ ] down.sql cleanly reverses the migration
  - [ ] public_apartments.yaml permissions include the new columns for user role
  - [ ] dc_prep completes with INFO Metadata is consistent
  - [ ] Attempting to INSERT with bathrooms = 0 is rejected by the CHECK constraint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added apartment details for bathrooms, capacity, maximum guests, floor area, and furnished status.
  * Added validation to ensure bathroom, capacity, and maximum guest values are positive.
  * Improved lookup performance for key apartment attributes.
  * These details are now available when viewing apartment listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->