### PR TITLE
[test]: Karate Big O performance benchmarks for reconciliation sync-  O(n) linear scaling

### DIFF
--- a/tests/karate/features/reconciliation/sync-escrows-performance.feature
+++ b/tests/karate/features/reconciliation/sync-escrows-performance.feature
@@ -17,8 +17,11 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
   # These tests use USE_MOCK_DATA=true so TW network calls are simulated.
   # The DB write path (syncChunk → UPSERT) is real.
   #
-  # Isolation: wipe safetrust escrow rows before seeding so chunk counts
-  # equal ⌈n/50⌉ for the scenario's n (sync selects every tenant='safetrust' row).
+  # Isolation: the sync handler only selects tenant_id='safetrust', so we cannot
+  # use a separate tenant without changing production code. Instead we stash
+  # non-benchmark safetrust rows to tenant 'safetrust_perf_stash', seed only
+  # PERF_/SCALE_/CTEST_CHUNK fixtures, then restore on afterScenario teardown
+  # (runs even when assertions fail).
 
   Background:
     * url webhookUrl
@@ -26,18 +29,42 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     * def clearPerfFixtures =
     """
     function() {
-      db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust' AND (contract_id LIKE 'PERF_TEST_%' OR contract_id LIKE 'SCALE_TEST_%' OR contract_id LIKE 'CTEST_CHUNK_%')");
+      db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id LIKE 'PERF_TEST_%' OR contract_id LIKE 'SCALE_TEST_%' OR contract_id LIKE 'CTEST_CHUNK_%'");
     }
     """
-    * def resetSafetrustEscrows =
+    * def stashNonBenchmarkEscrows =
     """
     function() {
-      db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'");
+      // Park other safetrust rows so chunk counts equal ⌈n/50⌉ for this scenario
+      // without DELETE-ing shared suite data.
+      db.execute("UPDATE public.trustless_work_escrows SET tenant_id = 'safetrust_perf_stash' WHERE tenant_id = 'safetrust'");
     }
     """
+    * def restoreStashedEscrows =
+    """
+    function() {
+      db.execute("UPDATE public.trustless_work_escrows SET tenant_id = 'safetrust' WHERE tenant_id = 'safetrust_perf_stash'");
+    }
+    """
+    * def teardownPerf =
+    """
+    function() {
+      clearPerfFixtures();
+      restoreStashedEscrows();
+    }
+    """
+    * def prepareBenchmark =
+    """
+    function() {
+      clearPerfFixtures();
+      stashNonBenchmarkEscrows();
+    }
+    """
+    # Failure-safe: always drop benchmark fixtures and restore stashed rows
+    * configure afterScenario = function(){ teardownPerf(); }
 
   Scenario: n=1 escrow — baseline O(1) sync duration < 5s
-    * resetSafetrustEscrows()
+    * prepareBenchmark()
     * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('PERF_TEST_001', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust') ON CONFLICT DO NOTHING")
     Given path '/reconciliation/sync-escrows'
     When method POST
@@ -45,14 +72,14 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     And match response.success == true
     And match response.totalEscrows == 1
     And match response.chunks == 1
+    And match response.errors == 0
     And assert response.durationMs < 5000
     # Persist baseline for the n=200 O(n) ratio check (scenarios do not share karate.set)
     * eval java.lang.System.setProperty('syncPerfBaselineMs', '' + response.durationMs)
     * karate.set('baseline', response.durationMs)
-    * clearPerfFixtures()
 
   Scenario: n=50 escrow — O(n) sync duration < 15s and chunks == 1
-    * resetSafetrustEscrows()
+    * prepareBenchmark()
     # seed-50-escrows.sql currently ships 42 CTEST_CHUNK rows; pad to exactly 50
     * db.execute(karate.read('file:tests/karate/fixtures/seed-50-escrows.sql'))
     * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_PAD_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 8) AS s(i) ON CONFLICT DO NOTHING")
@@ -62,11 +89,11 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     And match response.success == true
     And match response.totalEscrows == 50
     And match response.chunks == 1
+    And match response.errors == 0
     And assert response.durationMs < 15000
-    * clearPerfFixtures()
 
   Scenario: n=100 escrow — O(n) sync duration < 25s and chunks == 2
-    * resetSafetrustEscrows()
+    * prepareBenchmark()
     * db.execute(karate.read('file:tests/karate/fixtures/seed-50-escrows.sql'))
     * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_EXTRA_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 50) AS s(i) ON CONFLICT DO NOTHING")
     # 42 (fixture) + 50 extras + 8 pad = 100
@@ -77,11 +104,11 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     And match response.success == true
     And match response.totalEscrows == 100
     And match response.chunks == 2
+    And match response.errors == 0
     And assert response.durationMs < 25000
-    * clearPerfFixtures()
 
   Scenario: n=200 escrow — O(n) scaling ratio vs n=1 must be < 400 (rejects O(n²))
-    * resetSafetrustEscrows()
+    * prepareBenchmark()
     * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'SCALE_TEST_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 200) AS s(i) ON CONFLICT DO NOTHING")
     Given path '/reconciliation/sync-escrows'
     When method POST
@@ -89,6 +116,7 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     And match response.success == true
     And match response.totalEscrows == 200
     And match response.chunks == 4
+    And match response.errors == 0
     And assert response.durationMs < 50000
     # O(n) check: duration for 200 escrows should be < 400x duration for 1 escrow
     # O(n²) would give ~40000x ratio — far exceeds this bound
@@ -100,4 +128,3 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     * def ratio = response.durationMs / baseline
     * print 'sync O(n) ratio n=200/n=1 =', ratio, 'baselineMs=', baseline, 'durationMs=', response.durationMs
     And assert ratio < 400
-    * clearPerfFixtures()

--- a/tests/karate/features/reconciliation/sync-escrows-performance.feature
+++ b/tests/karate/features/reconciliation/sync-escrows-performance.feature
@@ -1,0 +1,103 @@
+Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
+
+  # Validates that sync duration grows linearly with n (number of escrows).
+  #
+  # Theory:
+  #   chunkArray(n, 50)            → O(n) time
+  #   fetchEscrowsByContractIds    → O(⌈n/50⌉) network calls
+  #   syncChunk per chunk          → O(k) DB writes, k <= 50
+  #   Total sync                   → O(n) dominated by DB writes
+  #
+  # Test strategy:
+  #   Run sync at n=1, 50, 100, 200.
+  #   Assert absolute ceiling per n (generous, network-tolerant).
+  #   Assert that durationMs(n=200) / durationMs(n=1) < 400
+  #   (allows for constant factors but rejects O(n²) which would give ratio ~40000)
+  #
+  # These tests use USE_MOCK_DATA=true so TW network calls are simulated.
+  # The DB write path (syncChunk → UPSERT) is real.
+  #
+  # Isolation: wipe safetrust escrow rows before seeding so chunk counts
+  # equal ⌈n/50⌉ for the scenario's n (sync selects every tenant='safetrust' row).
+
+  Background:
+    * url webhookUrl
+    * configure headers = { 'Content-Type': 'application/json' }
+    * def clearPerfFixtures =
+    """
+    function() {
+      db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust' AND (contract_id LIKE 'PERF_TEST_%' OR contract_id LIKE 'SCALE_TEST_%' OR contract_id LIKE 'CTEST_CHUNK_%')");
+    }
+    """
+    * def resetSafetrustEscrows =
+    """
+    function() {
+      db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'");
+    }
+    """
+
+  Scenario: n=1 escrow — baseline O(1) sync duration < 5s
+    * resetSafetrustEscrows()
+    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('PERF_TEST_001', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust') ON CONFLICT DO NOTHING")
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.totalEscrows == 1
+    And match response.chunks == 1
+    And assert response.durationMs < 5000
+    # Persist baseline for the n=200 O(n) ratio check (scenarios do not share karate.set)
+    * eval java.lang.System.setProperty('syncPerfBaselineMs', '' + response.durationMs)
+    * karate.set('baseline', response.durationMs)
+    * clearPerfFixtures()
+
+  Scenario: n=50 escrow — O(n) sync duration < 15s and chunks == 1
+    * resetSafetrustEscrows()
+    # seed-50-escrows.sql currently ships 42 CTEST_CHUNK rows; pad to exactly 50
+    * db.execute(karate.read('file:tests/karate/fixtures/seed-50-escrows.sql'))
+    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_PAD_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 8) AS s(i) ON CONFLICT DO NOTHING")
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.totalEscrows == 50
+    And match response.chunks == 1
+    And assert response.durationMs < 15000
+    * clearPerfFixtures()
+
+  Scenario: n=100 escrow — O(n) sync duration < 25s and chunks == 2
+    * resetSafetrustEscrows()
+    * db.execute(karate.read('file:tests/karate/fixtures/seed-50-escrows.sql'))
+    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_EXTRA_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 50) AS s(i) ON CONFLICT DO NOTHING")
+    # 42 (fixture) + 50 extras + 8 pad = 100
+    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_PAD_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 8) AS s(i) ON CONFLICT DO NOTHING")
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.totalEscrows == 100
+    And match response.chunks == 2
+    And assert response.durationMs < 25000
+    * clearPerfFixtures()
+
+  Scenario: n=200 escrow — O(n) scaling ratio vs n=1 must be < 400 (rejects O(n²))
+    * resetSafetrustEscrows()
+    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'SCALE_TEST_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 200) AS s(i) ON CONFLICT DO NOTHING")
+    Given path '/reconciliation/sync-escrows'
+    When method POST
+    Then status 200
+    And match response.success == true
+    And match response.totalEscrows == 200
+    And match response.chunks == 4
+    And assert response.durationMs < 50000
+    # O(n) check: duration for 200 escrows should be < 400x duration for 1 escrow
+    # O(n²) would give ~40000x ratio — far exceeds this bound
+    # This assertion catches quadratic regressions without requiring exact timing
+    # Baseline is set by the n=1 scenario via System property (karate.set does not span scenarios)
+    * def baselineStr = java.lang.System.getProperty('syncPerfBaselineMs')
+    * if (baselineStr == null) karate.fail('syncPerfBaselineMs missing — n=1 scenario must run first in this feature')
+    * def baseline = java.lang.Double.parseDouble(baselineStr)
+    * def ratio = response.durationMs / baseline
+    * print 'sync O(n) ratio n=200/n=1 =', ratio, 'baselineMs=', baseline, 'durationMs=', response.durationMs
+    And assert ratio < 400
+    * clearPerfFixtures()


### PR DESCRIPTION
## Summary
- Adds `tests/karate/features/reconciliation/sync-escrows-performance.feature` with parameterized sync benchmarks at n=1, 50, 100, and 200.
- Asserts absolute duration ceilings, expected chunk counts (`⌈n/50⌉`), and that `duration(n=200) / duration(n=1) < 400` to catch O(n²) regressions.
- Isolates seeds by clearing safetrust escrow rows before each run; pads the shared `seed-50-escrows.sql` fixture (42 rows) to exact n=50/100; persists the n=1 baseline via `System` property for the ratio check; cleans up PERF_/SCALE_/CTEST fixtures after scenarios.

Closes #468 

## Test plan
- [ ] `docker compose -f docker-compose-test.yml run --rm --build karate` (or scoped to `sync-escrows-performance.feature`) with `USE_MOCK_DATA=true`
- [ ] Confirm n=1 `<5s`, n=50 `<15s` + `chunks==1`, n=100 `<25s` + `chunks==2`, n=200 `<50s` + `chunks==4`
- [ ] Confirm n=200/n=1 duration ratio `<400`
- [ ] Confirm fixtures are cleaned up and no live TrustlessWork API is required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance coverage for escrow synchronization across 1, 50, 100, and 200 escrow records.
  * Added response validation for success status, escrow totals, chunking, and execution-time limits.
  * Added safeguards to detect significant runtime scaling regressions.
  * Added automatic cleanup of performance-test data after each scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->