### PR TITLE
feat: add handlers migration and share service to support and track o…

### DIFF
--- a/metadata/tenants/safetrust/databases/tables/public_trustless_work_webhook_events.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_trustless_work_webhook_events.yaml
@@ -1,0 +1,3 @@
+table:
+  name: trustless_work_webhook_events
+  schema: public

--- a/metadata/tenants/safetrust/databases/tables/tables.yaml
+++ b/metadata/tenants/safetrust/databases/tables/tables.yaml
@@ -16,3 +16,4 @@
 - "!include public_user_wallets.yaml"
 - "!include public_users.yaml"
 - "!include public_trustless_work_escrows.yaml"
+- "!include public_trustless_work_webhook_events.yaml"

--- a/migrations/safetrust/1777000000009_add_webhook_event_hash_index/down.sql
+++ b/migrations/safetrust/1777000000009_add_webhook_event_hash_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_webhook_events_contract_event_type;

--- a/migrations/safetrust/1777000000009_add_webhook_event_hash_index/up.sql
+++ b/migrations/safetrust/1777000000009_add_webhook_event_hash_index/up.sql
@@ -1,0 +1,7 @@
+-- Migration: Add hash index for O(1) webhook event deduplication lookup
+-- Description: Partial hash index on contract_id for processed safetrust events
+
+CREATE INDEX IF NOT EXISTS idx_webhook_events_contract_event_type
+  ON public.trustless_work_webhook_events
+  USING hash (contract_id)
+  WHERE processed = true AND tenant_id = 'safetrust';

--- a/tests/karate/features/escrows/fund.feature
+++ b/tests/karate/features/escrows/fund.feature
@@ -6,7 +6,7 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     # so escrow-created-001 is always reset to status: created, balance: 0
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-users.sql'))
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-escrows.sql'))
-    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded'")
+    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded' AND tenant_id = 'safetrust'")
 
   Scenario: Valid fund callback updates status to funded and sets balance
     * def body = { "contractId": "escrow-created-001", "signer": "GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z", "amount": 2500.00 }

--- a/tests/karate/features/escrows/fund.feature
+++ b/tests/karate/features/escrows/fund.feature
@@ -6,6 +6,7 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     # so escrow-created-001 is always reset to status: created, balance: 0
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-users.sql'))
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-escrows.sql'))
+    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded'")
 
   Scenario: Valid fund callback updates status to funded and sets balance
     * def body = { "contractId": "escrow-created-001", "signer": "GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z", "amount": 2500.00 }
@@ -20,6 +21,35 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
     And match rows[0].status == 'funded'
     And match rows[0].balance == '2500.0000000'
+
+  Scenario: Duplicate fund callback is idempotent
+    * def body = { "contractId": "escrow-created-001", "signer": "GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z", "amount": 2500.00 }
+    * def bodyStr = JSON.stringify(body)
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def afterFirst = db.query("SELECT status, balance, updated_at FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
+    And match afterFirst[0].status == 'funded'
+    And match afterFirst[0].balance == '2500.0000000'
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def afterSecond = db.query("SELECT status, balance, updated_at FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
+    And match afterSecond[0].status == 'funded'
+    And match afterSecond[0].balance == '2500.0000000'
+    And match afterSecond[0].updated_at == afterFirst[0].updated_at
+    * def events = db.query("SELECT processed FROM public.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded' ORDER BY created_at")
+    And match events.length == 2
+    And match events[0].processed == '#? _ == "true" || _ == "t" || _ == true'
+    And match events[1].processed == '#? _ == "true" || _ == "t" || _ == true'
 
   Scenario: Missing contractId returns 400
     * def body = { "signer": "GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z", "amount": 2500.00 }

--- a/webhook/src/routes/escrows/__tests__/approve-milestone.handler.test.js
+++ b/webhook/src/routes/escrows/__tests__/approve-milestone.handler.test.js
@@ -1,43 +1,27 @@
 'use strict';
 
+jest.mock('../../../services/hasura', () => ({
+  getHasuraEndpoint: jest.requireActual('../../../services/hasura').getHasuraEndpoint,
+  hasuraRequest: jest.fn(),
+  logAndCheckWebhookEvent: jest.fn(),
+  markWebhookEventProcessed: jest.fn(),
+}));
+
 const {
   approveMilestoneHandler,
   getHasuraEndpoint,
 } = require('../approve-milestone.handler');
+const {
+  hasuraRequest,
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+} = require('../../../services/hasura');
 
 function makeResponse() {
   return {
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
   };
-}
-
-function mockDedupFetch() {
-  global.fetch.mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({
-      data: { trustless_work_webhook_events: [] },
-    }),
-  });
-  global.fetch.mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({
-      data: {
-        insert_trustless_work_webhook_events_one: { id: 'event-1' },
-      },
-    }),
-  });
-}
-
-function mockMarkProcessedFetch() {
-  global.fetch.mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({
-      data: {
-        update_trustless_work_webhook_events_by_pk: { id: 'event-1' },
-      },
-    }),
-  });
 }
 
 describe('approveMilestoneHandler', () => {
@@ -47,7 +31,8 @@ describe('approveMilestoneHandler', () => {
     jest.clearAllMocks();
     process.env.HASURA_GRAPHQL_ADMIN_SECRET = 'test-secret';
     process.env.HASURA_GRAPHQL_ENDPOINT = 'http://graphql-engine-test:8080';
-    global.fetch = jest.fn();
+    logAndCheckWebhookEvent.mockResolvedValue({ isDuplicate: false, eventId: 'event-1' });
+    markWebhookEventProcessed.mockResolvedValue(undefined);
   });
 
   afterAll(() => {
@@ -85,41 +70,16 @@ describe('approveMilestoneHandler', () => {
     });
   });
 
-  it('updates Hasura and returns 200 when both updates succeed', async () => {
-    mockDedupFetch();
-
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          trustless_work_escrows: [{ id: 'escrow-1' }],
-        },
-      }),
+  it('uses milestone-specific idempotency keys', async () => {
+    hasuraRequest.mockResolvedValueOnce({
+      trustless_work_escrows: [{ id: 'escrow-1' }],
     });
-
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          update_escrow_milestones: {
-            affected_rows: 1,
-          },
-        },
-      }),
+    hasuraRequest.mockResolvedValueOnce({
+      update_escrow_milestones: { affected_rows: 1 },
     });
-
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          update_trustless_work_escrows: {
-            affected_rows: 1,
-          },
-        },
-      }),
+    hasuraRequest.mockResolvedValueOnce({
+      update_trustless_work_escrows: { affected_rows: 1 },
     });
-
-    mockMarkProcessedFetch();
 
     const req = {
       body: {
@@ -133,21 +93,69 @@ describe('approveMilestoneHandler', () => {
 
     await approveMilestoneHandler(req, res);
 
-    expect(global.fetch).toHaveBeenCalledTimes(6);
+    expect(logAndCheckWebhookEvent).toHaveBeenCalledWith(
+      'contract-1',
+      'milestone.approved:check_in',
+      req.body
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('updates Hasura and returns 200 when both updates succeed', async () => {
+    hasuraRequest.mockResolvedValueOnce({
+      trustless_work_escrows: [{ id: 'escrow-1' }],
+    });
+    hasuraRequest.mockResolvedValueOnce({
+      update_escrow_milestones: { affected_rows: 1 },
+    });
+    hasuraRequest.mockResolvedValueOnce({
+      update_trustless_work_escrows: { affected_rows: 1 },
+    });
+
+    const req = {
+      body: {
+        contractId: 'contract-1',
+        milestoneId: 'check_in',
+        approver: 'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
+        flag: true,
+      },
+    };
+    const res = makeResponse();
+
+    await approveMilestoneHandler(req, res);
+
+    expect(hasuraRequest).toHaveBeenCalledTimes(3);
+    expect(markWebhookEventProcessed).toHaveBeenCalledWith('event-1');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ received: true });
   });
 
-  it('returns 404 when the escrow is not found', async () => {
-    mockDedupFetch();
+  it('returns 200 without re-processing duplicate milestone approvals', async () => {
+    logAndCheckWebhookEvent.mockResolvedValueOnce({
+      isDuplicate: true,
+      eventId: 'event-duplicate',
+    });
 
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          trustless_work_escrows: [],
-        },
-      }),
+    const req = {
+      body: {
+        contractId: 'contract-1',
+        milestoneId: 'check_in',
+        approver: 'GABC',
+        flag: true,
+      },
+    };
+    const res = makeResponse();
+
+    await approveMilestoneHandler(req, res);
+
+    expect(hasuraRequest).not.toHaveBeenCalled();
+    expect(markWebhookEventProcessed).toHaveBeenCalledWith('event-duplicate');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 404 when the escrow is not found', async () => {
+    hasuraRequest.mockResolvedValueOnce({
+      trustless_work_escrows: [],
     });
 
     const req = {
@@ -166,26 +174,17 @@ describe('approveMilestoneHandler', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'Escrow or milestone not found',
     });
+    expect(markWebhookEventProcessed).not.toHaveBeenCalled();
   });
 
   it('returns 500 when Hasura responds with GraphQL errors during mutation', async () => {
-    mockDedupFetch();
-
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          trustless_work_escrows: [{ id: 'escrow-1' }],
-        },
-      }),
+    hasuraRequest.mockResolvedValueOnce({
+      trustless_work_escrows: [{ id: 'escrow-1' }],
     });
 
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        errors: [{ message: 'permission denied' }],
-      }),
-    });
+    const error = new Error('Hasura request failed');
+    error.details = [{ message: 'permission denied' }];
+    hasuraRequest.mockRejectedValueOnce(error);
 
     const req = {
       body: {
@@ -203,6 +202,7 @@ describe('approveMilestoneHandler', () => {
     expect(res.json).toHaveBeenCalledWith({
       error: 'Failed to update milestone approval',
     });
+    expect(markWebhookEventProcessed).not.toHaveBeenCalled();
   });
 });
 

--- a/webhook/src/routes/escrows/__tests__/approve-milestone.handler.test.js
+++ b/webhook/src/routes/escrows/__tests__/approve-milestone.handler.test.js
@@ -12,6 +12,34 @@ function makeResponse() {
   };
 }
 
+function mockDedupFetch() {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      data: { trustless_work_webhook_events: [] },
+    }),
+  });
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      data: {
+        insert_trustless_work_webhook_events_one: { id: 'event-1' },
+      },
+    }),
+  });
+}
+
+function mockMarkProcessedFetch() {
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      data: {
+        update_trustless_work_webhook_events_by_pk: { id: 'event-1' },
+      },
+    }),
+  });
+}
+
 describe('approveMilestoneHandler', () => {
   const originalEnv = { ...process.env };
 
@@ -57,63 +85,9 @@ describe('approveMilestoneHandler', () => {
     });
   });
 
-  it('updates Hasura and returns 200 when both updates succeed using custom camelCase', async () => {
-    // 1. Mock custom lookup succeeding
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          trustlessWorkEscrows: [{ id: 'escrow-1' }],
-        },
-      }),
-    });
+  it('updates Hasura and returns 200 when both updates succeed', async () => {
+    mockDedupFetch();
 
-    // 2. Mock custom milestone mutation succeeding
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          update_escrowMilestones: {
-            affected_rows: 1,
-          },
-        },
-      }),
-    });
-
-    // 3. Mock custom escrow mutation succeeding
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          update_trustlessWorkEscrows: {
-            affected_rows: 1,
-          },
-        },
-      }),
-    });
-
-    const req = {
-      body: {
-        contractId: 'contract-1',
-        milestoneId: 'check_in',
-        approver: 'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z',
-        flag: true,
-      },
-    };
-    const res = makeResponse();
-
-    await approveMilestoneHandler(req, res);
-
-    expect(global.fetch).toHaveBeenCalledTimes(3);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ received: true });
-  });
-
-  it('falls back to default snake_case when custom lookup/mutation fail or are not tracked', async () => {
-    // 1. Custom lookup fails (e.g. throws error or custom table not tracked)
-    global.fetch.mockRejectedValueOnce(new Error('custom not found'));
-
-    // 2. Default lookup succeeds
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -123,7 +97,6 @@ describe('approveMilestoneHandler', () => {
       }),
     });
 
-    // 3. Default milestone mutation succeeds
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -135,7 +108,6 @@ describe('approveMilestoneHandler', () => {
       }),
     });
 
-    // 4. Default escrow mutation succeeds
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -146,6 +118,8 @@ describe('approveMilestoneHandler', () => {
         },
       }),
     });
+
+    mockMarkProcessedFetch();
 
     const req = {
       body: {
@@ -159,23 +133,14 @@ describe('approveMilestoneHandler', () => {
 
     await approveMilestoneHandler(req, res);
 
-    expect(global.fetch).toHaveBeenCalledTimes(4);
+    expect(global.fetch).toHaveBeenCalledTimes(6);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ received: true });
   });
 
-  it('returns 404 when the escrow is not found in either lookup', async () => {
-    // 1. Custom lookup returns empty
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: {
-          trustlessWorkEscrows: [],
-        },
-      }),
-    });
+  it('returns 404 when the escrow is not found', async () => {
+    mockDedupFetch();
 
-    // 2. Default lookup returns empty
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -204,17 +169,17 @@ describe('approveMilestoneHandler', () => {
   });
 
   it('returns 500 when Hasura responds with GraphQL errors during mutation', async () => {
-    // 1. Custom lookup succeeds
+    mockDedupFetch();
+
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
         data: {
-          trustlessWorkEscrows: [{ id: 'escrow-1' }],
+          trustless_work_escrows: [{ id: 'escrow-1' }],
         },
       }),
     });
 
-    // 2. Custom mutation fails with errors
     global.fetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({

--- a/webhook/src/routes/escrows/approve-milestone.handler.js
+++ b/webhook/src/routes/escrows/approve-milestone.handler.js
@@ -29,7 +29,7 @@ async function approveMilestoneHandler(req, res) {
   try {
     const { isDuplicate, eventId } = await logAndCheckWebhookEvent(
       contractId,
-      EVENT_TYPE,
+      `${EVENT_TYPE}:${milestoneId}`,
       req.body
     );
 

--- a/webhook/src/routes/escrows/approve-milestone.handler.js
+++ b/webhook/src/routes/escrows/approve-milestone.handler.js
@@ -1,42 +1,13 @@
 'use strict';
 
-const DEFAULT_HASURA_ENDPOINT = 'http://graphql-engine:8080/v1/graphql';
+const {
+  hasuraRequest,
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+  getHasuraEndpoint,
+} = require('../../services/hasura');
 
-function getHasuraEndpoint() {
-  const configured = process.env.HASURA_GRAPHQL_ENDPOINT || DEFAULT_HASURA_ENDPOINT;
-  return configured.endsWith('/v1/graphql') ? configured : `${configured.replace(/\/$/, '')}/v1/graphql`;
-}
-
-async function postHasura(query, variables) {
-  const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
-
-  if (!adminSecret) {
-    throw new Error('Missing HASURA_GRAPHQL_ADMIN_SECRET');
-  }
-
-  const response = await fetch(getHasuraEndpoint(), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-hasura-admin-secret': adminSecret,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(`Hasura request failed with status ${response.status}`);
-  }
-
-  if (data.errors) {
-    const error = new Error('Hasura mutation failed');
-    error.details = data.errors;
-    throw error;
-  }
-
-  return data.data;
-}
+const EVENT_TYPE = 'milestone.approved';
 
 async function approveMilestoneHandler(req, res) {
   const { contractId, milestoneId, approver, flag } = req.body || {};
@@ -56,6 +27,17 @@ async function approveMilestoneHandler(req, res) {
   const approvedAt = new Date().toISOString();
 
   try {
+    const { isDuplicate, eventId } = await logAndCheckWebhookEvent(
+      contractId,
+      EVENT_TYPE,
+      req.body
+    );
+
+    if (isDuplicate) {
+      await markWebhookEventProcessed(eventId);
+      return res.status(200).json({ received: true });
+    }
+
     // Step 1: Look up the escrow ID using camelCase fields
     let escrowId;
 
@@ -66,7 +48,7 @@ async function approveMilestoneHandler(req, res) {
         }
       }
     `;
-    const data = await postHasura(lookupQuery, { contractId });
+    const data = await hasuraRequest(lookupQuery, { contractId });
     if (data.trustless_work_escrows && data.trustless_work_escrows.length > 0) {
       escrowId = data.trustless_work_escrows[0].id;
     }
@@ -101,7 +83,7 @@ async function approveMilestoneHandler(req, res) {
         }
       }
     `;
-    const resultMilestone = await postHasura(mutationMilestone, {
+    const resultMilestone = await hasuraRequest(mutationMilestone, {
       escrowId,
       milestoneId,
       approver,
@@ -133,7 +115,7 @@ async function approveMilestoneHandler(req, res) {
         }
       }
     `;
-    const resultEscrow = await postHasura(mutationEscrow, {
+    const resultEscrow = await hasuraRequest(mutationEscrow, {
       escrowId,
       approvedAt
     });
@@ -148,6 +130,7 @@ async function approveMilestoneHandler(req, res) {
     console.log(
       `[escrow/approve-milestone] milestone approved — contractId=${contractId} milestoneId=${milestoneId}`
     );
+    await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });
   } catch (error) {
     console.error('[escrow/approve-milestone] failed:', error.details || error.message);
@@ -160,5 +143,5 @@ async function approveMilestoneHandler(req, res) {
 module.exports = {
   approveMilestoneHandler,
   getHasuraEndpoint,
-  postHasura,
+  hasuraRequest,
 };

--- a/webhook/src/routes/escrows/dispute.handler.js
+++ b/webhook/src/routes/escrows/dispute.handler.js
@@ -1,3 +1,10 @@
+const {
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+} = require('../../services/hasura');
+
+const EVENT_TYPE = 'escrow.disputed';
+
 const disputeEscrowHandler = async (req, res) => {
   const { contractId, disputeFlag, disputer } = req.body;
 
@@ -27,6 +34,17 @@ const disputeEscrowHandler = async (req, res) => {
   `;
 
   try {
+    const { isDuplicate, eventId } = await logAndCheckWebhookEvent(
+      contractId,
+      EVENT_TYPE,
+      req.body
+    );
+
+    if (isDuplicate) {
+      await markWebhookEventProcessed(eventId);
+      return res.status(200).json({ received: true });
+    }
+
     const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
     const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
 
@@ -57,6 +75,7 @@ const disputeEscrowHandler = async (req, res) => {
     }
 
     console.log(`[escrow/dispute] Dispute opened — contractId: ${contractId}, disputer: ${disputer}`);
+    await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });
   } catch (error) {
     console.error('[escrow/dispute] Exception:', error.message);

--- a/webhook/src/routes/escrows/fund.handler.js
+++ b/webhook/src/routes/escrows/fund.handler.js
@@ -1,3 +1,10 @@
+const {
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+} = require('../../services/hasura');
+
+const EVENT_TYPE = 'escrow.funded';
+
 const fundEscrowHandler = async (req, res) => {
   const { contractId, signer, amount } = req.body;
 
@@ -38,6 +45,17 @@ const fundEscrowHandler = async (req, res) => {
   `;
 
   try {
+    const { isDuplicate, eventId } = await logAndCheckWebhookEvent(
+      contractId,
+      EVENT_TYPE,
+      req.body
+    );
+
+    if (isDuplicate) {
+      await markWebhookEventProcessed(eventId);
+      return res.status(200).json({ received: true });
+    }
+
     const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
     const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
 
@@ -82,7 +100,7 @@ const fundEscrowHandler = async (req, res) => {
 
     console.log(`[escrow/fund] Escrow funded — contractId: ${contractId}, amount: ${amount}`);
 
-    // 3 — Acknowledge TrustlessWork webhook
+    await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });
   } catch (error) {
     console.error('[escrow/fund] Exception:', error.message);

--- a/webhook/src/routes/escrows/release-funds.handler.js
+++ b/webhook/src/routes/escrows/release-funds.handler.js
@@ -1,3 +1,10 @@
+const {
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+} = require('../../services/hasura');
+
+const EVENT_TYPE = 'escrow.completed';
+
 const releaseFundsHandler = async (req, res) => {
   const { contractId, releaseSigner } = req.body;
 
@@ -22,6 +29,17 @@ const releaseFundsHandler = async (req, res) => {
   `;
 
   try {
+    const { isDuplicate, eventId } = await logAndCheckWebhookEvent(
+      contractId,
+      EVENT_TYPE,
+      req.body
+    );
+
+    if (isDuplicate) {
+      await markWebhookEventProcessed(eventId);
+      return res.status(200).json({ received: true });
+    }
+
     const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
     const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
 
@@ -53,6 +71,7 @@ const releaseFundsHandler = async (req, res) => {
     }
 
     console.log(`[escrow/release-funds] Funds released — contractId: ${contractId}`);
+    await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });
   } catch (error) {
     console.error('[escrow/release-funds] Exception:', error.message);

--- a/webhook/src/routes/escrows/resolve-dispute.handler.js
+++ b/webhook/src/routes/escrows/resolve-dispute.handler.js
@@ -1,3 +1,10 @@
+const {
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+} = require('../../services/hasura');
+
+const EVENT_TYPE = 'escrow.resolved';
+
 const resolveDisputeHandler = async (req, res) => {
   const { contractId, resolver, resolutionNote } = req.body;
 
@@ -32,6 +39,17 @@ const resolveDisputeHandler = async (req, res) => {
   `;
 
   try {
+    const { isDuplicate, eventId } = await logAndCheckWebhookEvent(
+      contractId,
+      EVENT_TYPE,
+      req.body
+    );
+
+    if (isDuplicate) {
+      await markWebhookEventProcessed(eventId);
+      return res.status(200).json({ received: true });
+    }
+
     const endpoint = process.env.HASURA_GRAPHQL_ENDPOINT;
     const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
 
@@ -72,7 +90,7 @@ const resolveDisputeHandler = async (req, res) => {
 
     console.log(`[escrow/resolve-dispute] Dispute resolved — contractId: ${contractId}, resolver: ${resolver}`);
 
-    // 3 — Acknowledge TrustlessWork webhook
+    await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });
   } catch (error) {
     console.error('[escrow/resolve-dispute] Exception:', error.message);

--- a/webhook/src/services/hasura.js
+++ b/webhook/src/services/hasura.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const DEFAULT_HASURA_ENDPOINT = 'http://graphql-engine:8080/v1/graphql';
+
+function getHasuraEndpoint() {
+  const configured = process.env.HASURA_GRAPHQL_ENDPOINT || DEFAULT_HASURA_ENDPOINT;
+  return configured.endsWith('/v1/graphql')
+    ? configured
+    : `${configured.replace(/\/$/, '')}/v1/graphql`;
+}
+
+/**
+ * Execute a Hasura GraphQL query or mutation.
+ * @param {string} query
+ * @param {object} [variables]
+ * @returns {Promise<object>}
+ */
+async function hasuraRequest(query, variables = {}) {
+  const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
+
+  if (!adminSecret) {
+    throw new Error('Missing HASURA_GRAPHQL_ADMIN_SECRET');
+  }
+
+  const response = await fetch(getHasuraEndpoint(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-hasura-admin-secret': adminSecret,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error(`Hasura request failed with status ${response.status}`);
+  }
+
+  if (data.errors) {
+    const error = new Error('Hasura request failed');
+    error.details = data.errors;
+    throw error;
+  }
+
+  return data.data;
+}
+
+/**
+ * Log an incoming webhook event and check if it was already processed.
+ * Uses trustless_work_webhook_events for O(1) deduplication via hash index.
+ *
+ * Big O:
+ *   Hash index lookup on (contract_id, event_type): O(1)
+ *   INSERT of new event record: O(1)
+ *   Total overhead per handler call: O(1)
+ *
+ * @param {string} contractId
+ * @param {string} eventType - e.g. 'escrow.funded', 'milestone.approved'
+ * @param {object} payload - raw request body
+ * @returns {Promise<{ isDuplicate: boolean, eventId: string }>}
+ */
+async function logAndCheckWebhookEvent(contractId, eventType, payload) {
+  const existing = await hasuraRequest(
+    `query CheckProcessed($contractId: String!, $eventType: String!) {
+      trustless_work_webhook_events(
+        where: {
+          contract_id: { _eq: $contractId }
+          event_type: { _eq: $eventType }
+          processed: { _eq: true }
+          tenant_id: { _eq: "safetrust" }
+        }
+        limit: 1
+      ) {
+        id
+      }
+    }`,
+    { contractId, eventType }
+  );
+
+  const isDuplicate = existing.trustless_work_webhook_events.length > 0;
+
+  const inserted = await hasuraRequest(
+    `mutation LogWebhookEvent(
+      $contractId: String
+      $eventType: String!
+      $payload: jsonb!
+    ) {
+      insert_trustless_work_webhook_events_one(
+        object: {
+          contract_id: $contractId
+          event_type: $eventType
+          payload: $payload
+          processed: false
+          tenant_id: "safetrust"
+        }
+      ) {
+        id
+      }
+    }`,
+    { contractId, eventType, payload }
+  );
+
+  return {
+    isDuplicate,
+    eventId: inserted.insert_trustless_work_webhook_events_one.id,
+  };
+}
+
+/**
+ * Mark a webhook event as processed.
+ * @param {string} eventId
+ */
+async function markWebhookEventProcessed(eventId) {
+  await hasuraRequest(
+    `mutation MarkProcessed($eventId: uuid!) {
+      update_trustless_work_webhook_events_by_pk(
+        pk_columns: { id: $eventId }
+        _set: { processed: true, processed_at: "now()" }
+      ) {
+        id
+      }
+    }`,
+    { eventId }
+  );
+}
+
+module.exports = {
+  getHasuraEndpoint,
+  hasuraRequest,
+  logAndCheckWebhookEvent,
+  markWebhookEventProcessed,
+};

--- a/webhook/src/services/hasura.js
+++ b/webhook/src/services/hasura.js
@@ -1,6 +1,10 @@
 'use strict';
 
+const { pool } = require('./db');
+
 const DEFAULT_HASURA_ENDPOINT = 'http://graphql-engine:8080/v1/graphql';
+const DEFAULT_HASURA_TIMEOUT_MS = 10000;
+const TENANT_ID = 'safetrust';
 
 function getHasuraEndpoint() {
   const configured = process.env.HASURA_GRAPHQL_ENDPOINT || DEFAULT_HASURA_ENDPOINT;
@@ -13,37 +17,46 @@ function getHasuraEndpoint() {
  * Execute a Hasura GraphQL query or mutation.
  * @param {string} query
  * @param {object} [variables]
+ * @param {number} [timeoutMs]
  * @returns {Promise<object>}
  */
-async function hasuraRequest(query, variables = {}) {
+async function hasuraRequest(query, variables = {}, timeoutMs = DEFAULT_HASURA_TIMEOUT_MS) {
   const adminSecret = process.env.HASURA_GRAPHQL_ADMIN_SECRET;
 
   if (!adminSecret) {
     throw new Error('Missing HASURA_GRAPHQL_ADMIN_SECRET');
   }
 
-  const response = await fetch(getHasuraEndpoint(), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-hasura-admin-secret': adminSecret,
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-  const data = await response.json();
+  try {
+    const response = await fetch(getHasuraEndpoint(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-hasura-admin-secret': adminSecret,
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
 
-  if (!response.ok) {
-    throw new Error(`Hasura request failed with status ${response.status}`);
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(`Hasura request failed with status ${response.status}`);
+    }
+
+    if (data.errors) {
+      const error = new Error('Hasura request failed');
+      error.details = data.errors;
+      throw error;
+    }
+
+    return data.data;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  if (data.errors) {
-    const error = new Error('Hasura request failed');
-    error.details = data.errors;
-    throw error;
-  }
-
-  return data.data;
 }
 
 /**
@@ -55,56 +68,60 @@ async function hasuraRequest(query, variables = {}) {
  *   INSERT of new event record: O(1)
  *   Total overhead per handler call: O(1)
  *
+ * Lookup and insert run in one PostgreSQL transaction with an advisory lock so
+ * concurrent deliveries for the same idempotency key cannot both proceed.
+ *
  * @param {string} contractId
- * @param {string} eventType - e.g. 'escrow.funded', 'milestone.approved'
+ * @param {string} eventType - e.g. 'escrow.funded', 'milestone.approved:check_in'
  * @param {object} payload - raw request body
  * @returns {Promise<{ isDuplicate: boolean, eventId: string }>}
  */
 async function logAndCheckWebhookEvent(contractId, eventType, payload) {
-  const existing = await hasuraRequest(
-    `query CheckProcessed($contractId: String!, $eventType: String!) {
-      trustless_work_webhook_events(
-        where: {
-          contract_id: { _eq: $contractId }
-          event_type: { _eq: $eventType }
-          processed: { _eq: true }
-          tenant_id: { _eq: "safetrust" }
-        }
-        limit: 1
-      ) {
-        id
-      }
-    }`,
-    { contractId, eventType }
-  );
+  const client = await pool.connect();
 
-  const isDuplicate = existing.trustless_work_webhook_events.length > 0;
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [
+      `${TENANT_ID}:${contractId}:${eventType}`,
+    ]);
 
-  const inserted = await hasuraRequest(
-    `mutation LogWebhookEvent(
-      $contractId: String
-      $eventType: String!
-      $payload: jsonb!
-    ) {
-      insert_trustless_work_webhook_events_one(
-        object: {
-          contract_id: $contractId
-          event_type: $eventType
-          payload: $payload
-          processed: false
-          tenant_id: "safetrust"
-        }
-      ) {
-        id
-      }
-    }`,
-    { contractId, eventType, payload }
-  );
+    const existing = await client.query(
+      `SELECT id
+       FROM public.trustless_work_webhook_events
+       WHERE contract_id = $1
+         AND event_type = $2
+         AND processed = true
+         AND tenant_id = $3
+       LIMIT 1`,
+      [contractId, eventType, TENANT_ID]
+    );
 
-  return {
-    isDuplicate,
-    eventId: inserted.insert_trustless_work_webhook_events_one.id,
-  };
+    const isDuplicate = existing.rows.length > 0;
+
+    const inserted = await client.query(
+      `INSERT INTO public.trustless_work_webhook_events (
+         contract_id,
+         event_type,
+         payload,
+         processed,
+         tenant_id
+       ) VALUES ($1, $2, $3, false, $4)
+       RETURNING id`,
+      [contractId, eventType, JSON.stringify(payload), TENANT_ID]
+    );
+
+    await client.query('COMMIT');
+
+    return {
+      isDuplicate,
+      eventId: inserted.rows[0].id,
+    };
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
 /**
@@ -112,16 +129,11 @@ async function logAndCheckWebhookEvent(contractId, eventType, payload) {
  * @param {string} eventId
  */
 async function markWebhookEventProcessed(eventId) {
-  await hasuraRequest(
-    `mutation MarkProcessed($eventId: uuid!) {
-      update_trustless_work_webhook_events_by_pk(
-        pk_columns: { id: $eventId }
-        _set: { processed: true, processed_at: "now()" }
-      ) {
-        id
-      }
-    }`,
-    { eventId }
+  await pool.query(
+    `UPDATE public.trustless_work_webhook_events
+     SET processed = true, processed_at = $2
+     WHERE id = $1`,
+    [eventId, new Date()]
   );
 }
 


### PR DESCRIPTION
# Summary

Implements **O(1) webhook idempotency** for TrustlessWork escrow callbacks.

# Closes #470 

TrustlessWork may retry webhook deliveries if the endpoint is slow. Previously, duplicate deliveries could re-execute Hasura mutations, resulting in duplicate processing and inflated reconciliation update counts.

This PR introduces a shared Hasura service that:

- Logs every incoming webhook to `trustless_work_webhook_events`
- Checks whether a `(contract_id, event_type)` pair has already been processed using a partial hash index
- Short-circuits duplicate deliveries with a `200 OK` response **without re-running the escrow mutation**

---

## Changes

### Shared Hasura Service
- **`webhook/src/services/hasura.js`**
  - Added `hasuraRequest`
  - Added `logAndCheckWebhookEvent` (O(1) lookup + audit insert)
  - Added `markWebhookEventProcessed`

### Escrow Handlers
Wrapped the following handlers with idempotency logic and standardized event type constants:

- `fund`
- `approve-milestone`
- `release-funds`
- `dispute`
- `resolve-dispute`

### Database Migration
- **Migration:** `1777000000009`
- Adds partial hash index:

```sql
idx_webhook_events_contract_event_type
```

on:

- `contract_id`

where:

```sql
processed = true
AND tenant_id = 'safetrust'
```

### Hasura Metadata
Tracks the `trustless_work_webhook_events` table so GraphQL insert/update mutations are available.

### Karate Tests
Added a duplicate **fund callback** scenario verifying idempotent behavior:

- Both requests return `200 OK`
- Escrow mutation executes only once
- Two audit rows are created and both are marked as processed

---

# Duplicate Delivery Behavior

For every webhook delivery:

1. Always insert a new audit row (preserves the complete retry history).
2. If a processed `(contract_id, event_type)` already exists:
   - Skip the escrow mutation.
   - Return:

```json
{ "received": true }
```

3. Mark the new audit row as `processed = true` after either:
   - Successful processing, or
   - Duplicate short-circuit.

4. Leave `processed = false` on `404` or `500` responses so future retries can be processed successfully.

---

# Test Plan

### Migration

```bash
bin/dc_prep safetrust
```

Verifies migrations and Hasura metadata apply successfully.

### Karate

```bash
docker compose -f docker-compose-test.yml run --rm --build karate
```

Expected:

- `fund.feature` passes
- Includes **Duplicate fund callback is idempotent**

### Unit Tests

```bash
cd webhook
npm test
```

Expected:

- `approve-milestone` unit tests pass (6/6)

### Manual Verification

```http
POST /api/escrows/fund
```

Send the same `contractId` twice.

Expected:

- Both requests return **200 OK**
- `escrow.updated_at` remains unchanged on the second request
- `trustless_work_webhook_events` contains **two** rows with:

```text
processed = true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook event tracking to prevent duplicate escrow operations.
  * Duplicate webhook deliveries are acknowledged safely without repeating updates.
  * Successfully handled events are marked as processed for improved traceability.
  * Added database support and indexing for faster processed-event lookups.

* **Bug Fixes**
  * Improved idempotency for escrow funding, milestone approval, disputes, dispute resolution, and fund release callbacks.

* **Tests**
  * Added coverage confirming repeated funding callbacks do not alter escrow state or timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->