### PR TITLE
test(karate): full escrow lifecycle state machine (#467)

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -151,11 +151,11 @@ services:
         curl -s -X POST http://graphql-engine-test:8080/v1/metadata -H 'X-Hasura-Admin-Secret: myadminsecretkey' -H 'Content-Type: application/json' -d '{\"type\": \"pg_add_source\", \"args\": {\"name\": \"safetrust\", \"configuration\": {\"connection_info\": { \"database_url\": \"postgres://postgres:postgrespassword@postgres_test:5432/postgres\", \"isolation_level\": \"read-committed\" } } } }';
         sleep 2;
         for i in 1 2 3 4 5; do hasura migrate apply --database-name safetrust --endpoint http://graphql-engine-test:8080 --admin-secret myadminsecretkey && break || sleep 5; done;
-        case \$(uname -m) in
+        case $$(uname -m) in
           aarch64|arm64) ARCH=arm64 ;;
           *) ARCH=amd64 ;;
         esac;
-        curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_\$ARCH -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq;
+        curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$$ARCH -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq;
         cd metadata && ./setup-tenant.sh safetrust --endpoint http://graphql-engine-test:8080 --admin-secret myadminsecretkey
       "
     depends_on:

--- a/metadata/deploy-tenant.sh
+++ b/metadata/deploy-tenant.sh
@@ -120,8 +120,14 @@ process_metadata_tables() {
     local temp_dir="$3"
     local hasura_endpoint="$4"
     local admin_secret="$5"
+    local has_errors=0
     
     echo "Processing tables for $tenant..."
+
+    if ! command -v yq >/dev/null 2>&1; then
+        echo "❌ yq is required to apply table customization (camelCase column mappings)" >&2
+        return 1
+    fi
     
     # Find all table definition files
     for table_file in "$temp_dir/metadata/databases/default/tables"/*.yaml; do
@@ -174,17 +180,24 @@ EOL
             # Keep GraphQL root field names as the SQL table name (omit custom_name)
             # so webhook mutations like insert_trustless_work_escrows_one keep working,
             # while camelCase column aliases (contractId, etc.) are applied.
-            if command -v yq >/dev/null 2>&1; then
-                local config_type
-                config_type=$(yq e '.configuration | type' "$table_file" 2>/dev/null || true)
-                if [ "$config_type" = "!!map" ]; then
-                    local config_json
-                    config_json=$(yq e -o=json '
-                      .configuration
-                      | del(.custom_name)
-                      | .
-                    ' "$table_file")
-                    cat > "$temp_dir/customize_table.json" << EOL
+            local config_type
+            if ! config_type=$(yq e '.configuration | type' "$table_file"); then
+                echo "❌ Failed reading configuration type from $table_file with yq" >&2
+                has_errors=1
+                continue
+            fi
+            if [ "$config_type" = "!!map" ]; then
+                local config_json
+                if ! config_json=$(yq e -o=json '
+                  .configuration
+                  | del(.custom_name)
+                  | .
+                ' "$table_file"); then
+                    echo "❌ Failed parsing configuration JSON from $table_file with yq" >&2
+                    has_errors=1
+                    continue
+                fi
+                cat > "$temp_dir/customize_table.json" << EOL
 {
   "type": "pg_set_table_customization",
   "args": {
@@ -197,22 +210,32 @@ EOL
   }
 }
 EOL
-                    echo "Applying table customization for $table_name..."
-                    local customize_response
-                    customize_response=$(curl -s -X POST "${hasura_endpoint}/v1/metadata" \
-                        -H "X-Hasura-Admin-Secret: ${admin_secret}" \
-                        -H "Content-Type: application/json" \
-                        -d @"$temp_dir/customize_table.json")
-                    if [[ "$customize_response" == *"error"* ]]; then
-                        echo "Warning: Issue customizing table $table_name: $customize_response"
-                    else
-                        echo "Successfully customized table $table_name"
-                    fi
+                echo "Applying table customization for $table_name..."
+                local customize_response
+                local curl_exit=0
+                customize_response=$(curl -sS --fail --connect-timeout 5 --max-time 30 \
+                    -X POST "${hasura_endpoint}/v1/metadata" \
+                    -H "X-Hasura-Admin-Secret: ${admin_secret}" \
+                    -H "Content-Type: application/json" \
+                    -d @"$temp_dir/customize_table.json") || curl_exit=$?
+                if [ "$curl_exit" -ne 0 ]; then
+                    echo "❌ Failed customizing table $table_name (curl exit ${curl_exit})" >&2
+                    has_errors=1
+                elif [[ "$customize_response" == *"error"* ]]; then
+                    echo "❌ Issue customizing table $table_name: $customize_response" >&2
+                    has_errors=1
+                else
+                    echo "Successfully customized table $table_name"
                 fi
             fi
         fi
     done
     
+    if [ "$has_errors" -ne 0 ]; then
+        echo "❌ Metadata deployment for $tenant tenant failed (table customization errors)" >&2
+        return 1
+    fi
+
     echo "✅ Metadata deployment for $tenant tenant completed"
     return 0
 }

--- a/metadata/deploy-tenant.sh
+++ b/metadata/deploy-tenant.sh
@@ -169,6 +169,47 @@ EOL
             else
                 echo "Successfully tracked table $table_name"
             fi
+
+            # Apply column/root customization from YAML when present.
+            # Keep GraphQL root field names as the SQL table name (omit custom_name)
+            # so webhook mutations like insert_trustless_work_escrows_one keep working,
+            # while camelCase column aliases (contractId, etc.) are applied.
+            if command -v yq >/dev/null 2>&1; then
+                local config_type
+                config_type=$(yq e '.configuration | type' "$table_file" 2>/dev/null || true)
+                if [ "$config_type" = "!!map" ]; then
+                    local config_json
+                    config_json=$(yq e -o=json '
+                      .configuration
+                      | del(.custom_name)
+                      | .
+                    ' "$table_file")
+                    cat > "$temp_dir/customize_table.json" << EOL
+{
+  "type": "pg_set_table_customization",
+  "args": {
+    "source": "${tenant_name}",
+    "table": {
+      "name": "${table_name}",
+      "schema": "${table_schema}"
+    },
+    "configuration": ${config_json}
+  }
+}
+EOL
+                    echo "Applying table customization for $table_name..."
+                    local customize_response
+                    customize_response=$(curl -s -X POST "${hasura_endpoint}/v1/metadata" \
+                        -H "X-Hasura-Admin-Secret: ${admin_secret}" \
+                        -H "Content-Type: application/json" \
+                        -d @"$temp_dir/customize_table.json")
+                    if [[ "$customize_response" == *"error"* ]]; then
+                        echo "Warning: Issue customizing table $table_name: $customize_response"
+                    else
+                        echo "Successfully customized table $table_name"
+                    fi
+                fi
+            fi
         fi
     done
     

--- a/tests/karate/features/escrows/escrow-lifecycle.feature
+++ b/tests/karate/features/escrows/escrow-lifecycle.feature
@@ -78,7 +78,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero, amount FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero, amount FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match rows[0].status == 'created'
     And match rows[0].balance_is_zero == '1'
     And match rows[0].amount == '1200.0000000'
@@ -160,7 +160,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match rows[0].status == 'completed'
     And match rows[0].balance_is_zero == '1'
     # Post-completion: re-fund must still be rejected (status guard holds).
@@ -247,7 +247,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     * def elapsed = Java.type('java.lang.System').currentTimeMillis() - start
     # O(4) Hasura-backed transitions: should complete < 10s under normal load
     And assert elapsed < 10000
-    * def finalRows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * def finalRows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
     And match finalRows[0].status == 'completed'
     And match finalRows[0].balance_is_zero == '1'
     * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
@@ -313,7 +313,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     And request resolveStr
     When method POST
     Then status 200
-    * def resolved = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    * def resolved = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
     And match resolved[0].status == 'resolved'
     And match resolved[0].balance_is_zero == '1'
 

--- a/tests/karate/features/escrows/escrow-lifecycle.feature
+++ b/tests/karate/features/escrows/escrow-lifecycle.feature
@@ -1,0 +1,329 @@
+Feature: Full escrow lifecycle state machine — O(steps) sequential validation
+
+  # Validates the complete single-release escrow lifecycle in order:
+  #   initialize → fund → approve-milestone → release-funds
+  #
+  # Also validates the dispute branch:
+  #   initialize → fund → dispute → resolve-dispute
+  #
+  # Big O properties under test:
+  #   Each status transition: O(1) — single Hasura mutation, single DB write
+  #   Full lifecycle (n=1 milestone): O(4) transitions = O(n_steps)
+  #   Dispute branch: O(4) transitions (init → fund → dispute → resolve)
+  #   Total wall clock for full lifecycle: must complete < 10s (network-bound)
+  #
+  # This feature is ORDER-DEPENDENT by design for Steps 1–4 / 2b.
+  # Do not reorder those scenarios.
+  #
+  # Caveats vs naive Background DELETE:
+  #   Karate runs Background before EVERY Scenario. Deleting lifecycle
+  #   contract IDs in Background would wipe Step 1's row before Step 2.
+  #   Cleanup runs once at feature start (Step 1) and again in afterFeature.
+  #
+  # Auth: every webhook call must HMAC-sign the exact request body string
+  # (same pattern as fund.feature / approve-milestone.feature).
+  #
+  # Idempotency caveat (handlers):
+  #   logAndCheckWebhookEvent short-circuits on (contract_id, event_type) with
+  #   processed=true → 200 before Hasura status filters run. Status-guard
+  #   assertions clear the relevant webhook_events row first so the mutation
+  #   path (and its 404) is actually exercised.
+
+  Background:
+    * url webhookUrl
+    * configure headers = { 'Content-Type': 'application/json' }
+    * def lifecycleContractId = 'LIFECYCLE_TEST_CONTRACT_001'
+    * def disputeContractId = 'DISPUTE_TEST_CONTRACT_001'
+    * def timingContractId = 'TIMING_TEST_001'
+    * def marker = 'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z'
+    * def approver = 'GAPPROVER111WALLETADDRESS111111111111111111111111111111111'
+    * def releaser = 'GRELEASER111WALLETADDRESS111111111111111111111111111111111'
+    * def resolver = 'GRESOLVER111WALLETADDRESS111111111111111111111111111111111'
+    # Hardcode IDs inside JS helpers — Karate closures do not always capture
+    # Background `def` bindings reliably across afterFeature.
+    * def cleanupLifecycleFixtures =
+    """
+    function() {
+      var ids = "('LIFECYCLE_TEST_CONTRACT_001','DISPUTE_TEST_CONTRACT_001','TIMING_TEST_001')";
+      // Cascades escrow_milestones; also drop webhook idempotency rows for these contracts.
+      db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id IN " + ids);
+      db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id IN " + ids);
+    }
+    """
+    # Failure-safe: remove this feature's fixtures even if a later scenario fails.
+    # Must NOT run between Steps 1–4 (would break order dependence), so we only
+    # clean at feature end — not afterScenario.
+    * configure afterFeature = function(){ cleanupLifecycleFixtures(); }
+
+  # ── Step 1: Initialize ────────────────────────────────────────────────────
+  Scenario: Step 1 — initialize creates escrow with status created
+    * cleanupLifecycleFixtures()
+    * def body =
+    """
+    {
+      "contract_id": "#(lifecycleContractId)",
+      "marker": "#(marker)",
+      "approver": "#(approver)",
+      "releaser": "#(releaser)",
+      "amount": 1200.00,
+      "escrow_type": "single_release",
+      "asset_code": "USDC"
+    }
+    """
+    * def bodyStr = JSON.stringify(body)
+    Given path '/api/escrows/initialize'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero, amount FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    And match rows[0].status == 'created'
+    And match rows[0].balance_is_zero == '1'
+    And match rows[0].amount == '1200.0000000'
+
+  # ── Step 2: Fund — O(1) transition, only valid from created/pending_funding ─
+  Scenario: Step 2 — fund transitions status to funded and sets balance
+    * def body = { "contractId": "#(lifecycleContractId)", "signer": "#(approver)", "amount": 1200.00 }
+    * def bodyStr = JSON.stringify(body)
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    And match rows[0].status == 'funded'
+    And match rows[0].balance == '1200.0000000'
+
+  # ── Guard: fund is status-gated — cannot fund a funded escrow ─────────────
+  Scenario: Step 2b — funding an already-funded escrow returns 404 (status guard)
+    # IMPORTANT: webhook idempotency short-circuits on (contract_id, event_type)
+    # before the Hasura status filter runs. A second identical fund callback would
+    # return 200 { received: true } without testing the status guard. Clear the
+    # processed escrow.funded event so this request exercises the mutation path.
+    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = '" + lifecycleContractId + "' AND event_type = 'escrow.funded'")
+    * def body = { "contractId": "#(lifecycleContractId)", "signer": "#(approver)", "amount": 1200.00 }
+    * def bodyStr = JSON.stringify(body)
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    # status is 'funded' — not in ['created', 'pending_funding'] — returns 404
+    Then status 404
+    And match response.error contains 'Escrow not found'
+    # Guard must not mutate funded state / balance
+    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    And match rows[0].status == 'funded'
+    And match rows[0].balance == '1200.0000000'
+
+  # ── Step 3: Approve milestone — O(2) DB writes: milestone + escrow ────────
+  Scenario: Step 3 — approve-milestone updates milestone and advances escrow to milestone_approved
+    * def milestoneEscrowId = db.query("SELECT id FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")[0].id
+    * db.execute("INSERT INTO public.escrow_milestones (escrow_id, milestone_id, description, amount, status, tenant_id) VALUES ('" + milestoneEscrowId + "', 'check_in', 'Test milestone', 1200.0, 'pending', 'safetrust') ON CONFLICT (escrow_id, milestone_id) DO NOTHING")
+    * def body =
+    """
+    {
+      "contractId": "#(lifecycleContractId)",
+      "milestoneId": "check_in",
+      "approver": "#(approver)",
+      "flag": true
+    }
+    """
+    * def bodyStr = JSON.stringify(body)
+    Given path '/api/escrows/approve-milestone'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def milestone = db.query("SELECT status, approved_by FROM public.escrow_milestones WHERE milestone_id = 'check_in' AND escrow_id = '" + milestoneEscrowId + "'")
+    And match milestone[0].status == 'approved'
+    And match milestone[0].approved_by == approver
+    * def escrow = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    And match escrow[0].status == 'milestone_approved'
+    # Approval must not zero / alter funded balance
+    And match escrow[0].balance == '1200.0000000'
+
+  # ── Step 4: Release funds — O(1) transition, balance zeroed ───────────────
+  Scenario: Step 4 — release-funds completes escrow and zeroes balance
+    * def body = { "contractId": "#(lifecycleContractId)", "releaseSigner": "#(releaser)" }
+    * def bodyStr = JSON.stringify(body)
+    Given path '/api/escrows/release-funds'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(bodyStr)
+    And request bodyStr
+    When method POST
+    Then status 200
+    And match response.received == true
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    And match rows[0].status == 'completed'
+    And match rows[0].balance_is_zero == '1'
+    # Post-completion: re-fund must still be rejected (status guard holds).
+    # Clear idempotency row so we hit the Hasura status filter, not the 200 duplicate path.
+    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = '" + lifecycleContractId + "' AND event_type = 'escrow.funded'")
+    * def fundAgain = { "contractId": "#(lifecycleContractId)", "signer": "#(approver)", "amount": 1200.00 }
+    * def fundAgainStr = JSON.stringify(fundAgain)
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(fundAgainStr)
+    And request fundAgainStr
+    When method POST
+    Then status 404
+
+  # ── Performance: full 4-step lifecycle completes in O(steps) wall-clock ───
+  Scenario: Full lifecycle timing — 4 transitions complete within 10 seconds total
+    # Measures initialize → fund → approve-milestone → release-funds (true O(4)).
+    # Issue draft skipped approve-milestone; that would only prove O(3) and would
+    # not exercise the milestone_approved state at all.
+    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * def start = Java.type('java.lang.System').currentTimeMillis()
+
+    # 1) Initialize
+    * def initBody =
+    """
+    {
+      "contract_id": "#(timingContractId)",
+      "marker": "#(marker)",
+      "approver": "#(approver)",
+      "releaser": "#(releaser)",
+      "amount": 500.00,
+      "escrow_type": "single_release",
+      "asset_code": "USDC"
+    }
+    """
+    * def initStr = JSON.stringify(initBody)
+    Given path '/api/escrows/initialize'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(initStr)
+    And request initStr
+    When method POST
+    Then status 200
+
+    # 2) Fund
+    * def fundBody = { "contractId": "#(timingContractId)", "signer": "#(approver)", "amount": 500.00 }
+    * def fundStr = JSON.stringify(fundBody)
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(fundStr)
+    And request fundStr
+    When method POST
+    Then status 200
+
+    # 3) Approve milestone (seed row — initialize does not create milestones)
+    * def timingEscrowId = db.query("SELECT id FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")[0].id
+    * db.execute("INSERT INTO public.escrow_milestones (escrow_id, milestone_id, description, amount, status, tenant_id) VALUES ('" + timingEscrowId + "', 'check_in', 'Timing milestone', 500.0, 'pending', 'safetrust') ON CONFLICT (escrow_id, milestone_id) DO NOTHING")
+    * def approveBody =
+    """
+    {
+      "contractId": "#(timingContractId)",
+      "milestoneId": "check_in",
+      "approver": "#(approver)",
+      "flag": true
+    }
+    """
+    * def approveStr = JSON.stringify(approveBody)
+    Given path '/api/escrows/approve-milestone'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(approveStr)
+    And request approveStr
+    When method POST
+    Then status 200
+
+    # 4) Release
+    * def releaseBody = { "contractId": "#(timingContractId)", "releaseSigner": "#(releaser)" }
+    * def releaseStr = JSON.stringify(releaseBody)
+    Given path '/api/escrows/release-funds'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(releaseStr)
+    And request releaseStr
+    When method POST
+    Then status 200
+
+    * def elapsed = Java.type('java.lang.System').currentTimeMillis() - start
+    # O(4) Hasura-backed transitions: should complete < 10s under normal load
+    And assert elapsed < 10000
+    * def finalRows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    And match finalRows[0].status == 'completed'
+    And match finalRows[0].balance_is_zero == '1'
+    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * def leftover = db.query("SELECT count(*)::text AS c FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    And match leftover[0].c == '0'
+
+  # ── Dispute branch: initialize → fund → dispute → resolve ─────────────────
+  Scenario: Dispute branch — fund then dispute then resolve transitions correctly
+    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    # Initialize
+    * def initBody =
+    """
+    {
+      "contract_id": "#(disputeContractId)",
+      "marker": "#(marker)",
+      "approver": "#(approver)",
+      "releaser": "#(releaser)",
+      "resolver": "#(resolver)",
+      "amount": 800.00,
+      "escrow_type": "single_release",
+      "asset_code": "USDC"
+    }
+    """
+    * def initStr = JSON.stringify(initBody)
+    Given path '/api/escrows/initialize'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(initStr)
+    And request initStr
+    When method POST
+    Then status 200
+
+    # Fund
+    * def fundBody = { "contractId": "#(disputeContractId)", "signer": "#(approver)", "amount": 800.00 }
+    * def fundStr = JSON.stringify(fundBody)
+    Given path '/api/escrows/fund'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(fundStr)
+    And request fundStr
+    When method POST
+    Then status 200
+
+    # Dispute — status → disputed; balance must remain funded amount
+    * def disputeBody = { "contractId": "#(disputeContractId)", "disputeFlag": true, "disputer": "#(approver)" }
+    * def disputeStr = JSON.stringify(disputeBody)
+    Given path '/api/escrows/dispute'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(disputeStr)
+    And request disputeStr
+    When method POST
+    Then status 200
+    * def disputed = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    And match disputed[0].status == 'disputed'
+    And match disputed[0].balance == '800.0000000'
+
+    # Resolve from non-disputed must 404 — use a funded sibling to prove guard
+    # (here: attempt resolve twice after success is covered below; first prove
+    # resolve only matches status=disputed by resolving once then retrying).
+    * def resolveBody = { "contractId": "#(disputeContractId)", "resolver": "#(resolver)", "resolutionNote": "Resolved" }
+    * def resolveStr = JSON.stringify(resolveBody)
+    Given path '/api/escrows/resolve-dispute'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(resolveStr)
+    And request resolveStr
+    When method POST
+    Then status 200
+    * def resolved = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    And match resolved[0].status == 'resolved'
+    And match resolved[0].balance_is_zero == '1'
+
+    # Status guard: resolve again must 404 (no longer disputed).
+    # Clear idempotency so we exercise status=_eq disputed, not the 200 duplicate path.
+    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = '" + disputeContractId + "' AND event_type = 'escrow.resolved'")
+    Given path '/api/escrows/resolve-dispute'
+    And header Content-Type = 'application/json'
+    And header x-trustlesswork-signature = trustlessWorkSignature(resolveStr)
+    And request resolveStr
+    When method POST
+    Then status 404
+    And match response.error contains 'Escrow not found'


### PR DESCRIPTION
## Summary
- Adds `tests/karate/features/escrows/escrow-lifecycle.feature` with 7 order-dependent scenarios covering `created → funded → milestone_approved → completed`, status-guard 404s, dispute→resolve, and &lt;10s timing.
- Clears webhook idempotency rows before re-fund / re-resolve so Hasura status filters (not the processed-event short-circuit) are exercised.
- Fixes test infra needed for escrow GraphQL locally: compose `$$ARCH` escape for yq download, and `deploy-tenant.sh` applies camelCase column customizations (`contractId`, etc.) without renaming GraphQL roots.

Closes #467

## Test plan
- [x] `docker compose -f docker-compose-test.yml run --rm karate` path for lifecycle: **7/7 passed**
- [x] Step 2b returns 404 after clearing `escrow.funded` webhook event
- [x] Step 3 advances milestone + escrow to `milestone_approved`
- [x] Timing scenario &lt; 10s; no leftover `TIMING_TEST_001`
- [x] Dispute branch ends `resolved` with balance `0`
- [ ] CI Karate job on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test-environment setup so architecture detection and `yq` downloads run reliably inside Docker Compose across supported platforms.
  - Deployment now applies Hasura table customizations from each table’s configuration (when `yq` is available), with hard-fail behavior and clearer error reporting on customization parsing or apply failures.

- **Tests**
  - Added an end-to-end escrow lifecycle Karate suite covering the full happy path, invalid transition guards (no state mutation), milestone effects, dispute resolution, and overall flow timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->