### PR TITLE
feat: add POST /api/hotel/conversations/send

### DIFF
--- a/webhook/src/routes/escrows/fund.handler.js
+++ b/webhook/src/routes/escrows/fund.handler.js
@@ -3,6 +3,9 @@ const {
   logAndCheckWebhookEvent,
   markWebhookEventProcessed,
 } = require('../../services/hasura');
+const {
+  notifyHotelEscrowConversation,
+} = require('../../services/hotel-conversation-notify');
 
 const EVENT_TYPE = 'escrow.funded';
 
@@ -66,7 +69,15 @@ const fundEscrowHandler = async (req, res) => {
       });
     }
 
-    console.log(`[escrow/fund] Escrow funded — contractId: ${contractId}, amount: ${amount}`);
+    console.log(`[escrow/fund] ✅ escrow funded — contractId: ${contractId}`);
+
+    // Best-effort hotel lifecycle message — never fail the fund response
+    await notifyHotelEscrowConversation({
+      contractId,
+      eventType: 'escrow_funded',
+      body:
+        'SafeTrust: Your deposit has been confirmed on the Stellar network. Your booking is secured.',
+    });
 
     await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });

--- a/webhook/src/routes/escrows/release-funds.handler.js
+++ b/webhook/src/routes/escrows/release-funds.handler.js
@@ -3,6 +3,9 @@ const {
   logAndCheckWebhookEvent,
   markWebhookEventProcessed,
 } = require('../../services/hasura');
+const {
+  notifyHotelEscrowConversation,
+} = require('../../services/hotel-conversation-notify');
 
 const EVENT_TYPE = 'escrow.completed';
 
@@ -48,7 +51,16 @@ const releaseFundsHandler = async (req, res) => {
       return res.status(404).json({ error: `Escrow not found for contractId: ${contractId}` });
     }
 
-    console.log(`[escrow/release-funds] Funds released — contractId: ${contractId}`);
+    console.log(`[escrow/release-funds] ✅ funds released — contractId: ${contractId}`);
+
+    // Best-effort hotel lifecycle message — never fail the release response
+    await notifyHotelEscrowConversation({
+      contractId,
+      eventType: 'escrow_completed',
+      body:
+        'SafeTrust: Funds have been released. Thank you for booking with us.',
+    });
+
     await markWebhookEventProcessed(eventId);
     return res.status(200).json({ received: true });
   } catch (error) {

--- a/webhook/src/routes/hotel/conversations/__tests__/send.handler.test.js
+++ b/webhook/src/routes/hotel/conversations/__tests__/send.handler.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+jest.mock('../../../../services/db', () => ({
+  query: jest.fn(),
+}));
+
+const db = require('../../../../services/db');
+const { sendHotelConversationHandler } = require('../send.handler');
+
+function makeResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
+
+const ids = {
+  reservationId: '11111111-1111-4111-8111-111111111111',
+  hostId: '22222222-2222-4222-8222-222222222222',
+  guestId: '33333333-3333-4333-8333-333333333333',
+  senderId: '33333333-3333-4333-8333-333333333333',
+  conversationId: '44444444-4444-4444-8444-444444444444',
+  messageId: '55555555-5555-4555-8555-555555555555',
+};
+
+describe('sendHotelConversationHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const req = { body: { reservationId: ids.reservationId } };
+    const res = makeResponse();
+
+    await sendHotelConversationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.stringContaining('Missing required fields'),
+      }),
+    );
+  });
+
+  it('finds existing conversation and appends a message', async () => {
+    const createdAt = new Date('2026-07-27T00:00:00.000Z');
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: ids.conversationId }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: ids.messageId, created_at: createdAt }],
+      });
+
+    const req = {
+      body: {
+        ...ids,
+        body: 'Hello from guest',
+      },
+    };
+    const res = makeResponse();
+
+    await sendHotelConversationHandler(req, res);
+
+    expect(db.query).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      conversationId: ids.conversationId,
+      messageId: ids.messageId,
+      lastMessageAt: createdAt,
+    });
+  });
+
+  it('creates a conversation when none exists', async () => {
+    const createdAt = new Date('2026-07-27T00:00:00.000Z');
+    db.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: ids.conversationId }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: ids.messageId, created_at: createdAt }],
+      });
+
+    const req = {
+      body: {
+        ...ids,
+        body: 'First message',
+        escrowTransactionId: '66666666-6666-4666-8666-666666666666',
+      },
+    };
+    const res = makeResponse();
+
+    await sendHotelConversationHandler(req, res);
+
+    expect(db.query).toHaveBeenCalledTimes(3);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      conversationId: ids.conversationId,
+      messageId: ids.messageId,
+      lastMessageAt: createdAt,
+    });
+  });
+});

--- a/webhook/src/routes/hotel/conversations/send.handler.js
+++ b/webhook/src/routes/hotel/conversations/send.handler.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const db = require('../../../services/db');
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const REQUIRED = ['reservationId', 'hostId', 'guestId', 'senderId', 'body'];
+
+/**
+ * Find-or-create a hotel conversation for a reservation/host/guest triple,
+ * then append a message. DB trigger updates conversations.last_message_at.
+ */
+async function sendHotelConversationHandler(req, res) {
+  const {
+    reservationId,
+    hostId,
+    guestId,
+    senderId,
+    body,
+    isAutomated = false,
+    eventType = null,
+    escrowTransactionId = null,
+  } = req.body || {};
+
+  const missing = REQUIRED.filter((key) => {
+    const value = req.body?.[key];
+    return value === undefined || value === null || String(value).trim() === '';
+  });
+
+  if (missing.length > 0) {
+    console.error(
+      `[conversations/send] ❌ missing required fields: ${missing.join(', ')}`,
+    );
+    return res.status(400).json({
+      error: `Missing required fields: ${missing.join(', ')}`,
+    });
+  }
+
+  for (const [label, value] of [
+    ['reservationId', reservationId],
+    ['hostId', hostId],
+    ['guestId', guestId],
+    ['senderId', senderId],
+  ]) {
+    if (!UUID_RE.test(String(value))) {
+      return res.status(400).json({ error: `${label} must be a valid UUID` });
+    }
+  }
+
+  if (
+    escrowTransactionId != null &&
+    escrowTransactionId !== '' &&
+    !UUID_RE.test(String(escrowTransactionId))
+  ) {
+    return res
+      .status(400)
+      .json({ error: 'escrowTransactionId must be a valid UUID or null' });
+  }
+
+  const text = String(body).trim();
+  if (!text || text.length > 4000) {
+    return res.status(400).json({
+      error: 'body must be between 1 and 4000 characters',
+    });
+  }
+
+  if (eventType != null && !isAutomated) {
+    return res.status(400).json({
+      error: 'eventType is only allowed when isAutomated is true',
+    });
+  }
+
+  if (String(hostId) === String(guestId)) {
+    return res.status(400).json({
+      error: 'hostId and guestId must be different',
+    });
+  }
+
+  try {
+    let conversationId;
+
+    const existing = await db.query(
+      `SELECT id FROM public.conversations
+       WHERE reservation_id = $1 AND host_id = $2 AND guest_id = $3`,
+      [reservationId, hostId, guestId],
+    );
+
+    conversationId = existing.rows[0]?.id;
+
+    if (!conversationId) {
+      try {
+        const created = await db.query(
+          `INSERT INTO public.conversations
+             (reservation_id, host_id, guest_id, escrow_transaction_id)
+           VALUES ($1, $2, $3, $4)
+           RETURNING id`,
+          [
+            reservationId,
+            hostId,
+            guestId,
+            escrowTransactionId || null,
+          ],
+        );
+        conversationId = created.rows[0].id;
+      } catch (err) {
+        // Concurrent find-or-create race — unique_hotel_conversation
+        if (err.code === '23505') {
+          const again = await db.query(
+            `SELECT id FROM public.conversations
+             WHERE reservation_id = $1 AND host_id = $2 AND guest_id = $3`,
+            [reservationId, hostId, guestId],
+          );
+          conversationId = again.rows[0]?.id;
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    if (!conversationId) {
+      return res.status(500).json({ error: 'Failed to resolve conversation' });
+    }
+
+    const msg = await db.query(
+      `INSERT INTO public.messages
+         (conversation_id, sender_id, body, is_automated, event_type)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING id, created_at`,
+      [
+        conversationId,
+        senderId,
+        text,
+        Boolean(isAutomated),
+        eventType ?? null,
+      ],
+    );
+
+    const messageId = msg.rows[0].id;
+    const lastMessageAt = msg.rows[0].created_at;
+
+    if (isAutomated) {
+      console.log(
+        `[conversations/send] ✅ automated message sent — event_type: ${eventType} conversationId: ${conversationId}, messageId: ${messageId}`,
+      );
+    } else {
+      console.log(
+        `[conversations/send] ✅ message sent — conversationId: ${conversationId}, messageId: ${messageId}`,
+      );
+    }
+
+    return res.status(200).json({
+      conversationId,
+      messageId,
+      lastMessageAt,
+    });
+  } catch (error) {
+    console.error('[conversations/send] ❌ error:', error.message);
+    return res.status(500).json({ error: 'Failed to send message' });
+  }
+}
+
+module.exports = { sendHotelConversationHandler };

--- a/webhook/src/routes/hotel/conversations/send.route.js
+++ b/webhook/src/routes/hotel/conversations/send.route.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const express = require('express');
+const { sendHotelConversationHandler } = require('./send.handler');
+
+const router = express.Router();
+
+// Internal/service route — called by escrow handlers and clients.
+// Registered before Firebase auth (see routes/index.js).
+router.post('/api/hotel/conversations/send', sendHotelConversationHandler);
+
+module.exports = router;

--- a/webhook/src/routes/index.js
+++ b/webhook/src/routes/index.js
@@ -16,6 +16,7 @@ const initializeEscrowRoute = require('./escrows/initialize.route');
 const fundEscrowRoute = require('./escrows/fund.route');
 const releaseFundsRoute = require('./escrows/release-funds.route');
 const resolveDisputeRoute = require('./escrows/resolve-dispute.route');
+const hotelConversationsSendRoute = require('./hotel/conversations/send.route');
 
 // 1. Health Check
 router.get('/health', (req, res) => res.status(200).send('OK'))
@@ -29,6 +30,8 @@ router.use(fundEscrowRoute)
 router.use(releaseFundsRoute)
 router.use(resolveDisputeRoute)
 router.use(escrowRoutes)
+// Hotel messaging — internal + client send (no TW signature)
+router.use(hotelConversationsSendRoute)
 
 // 3. Authenticated Routes & Auth Middlewares
 router.use('/api', authMiddleware)

--- a/webhook/src/services/hotel-conversation-notify.js
+++ b/webhook/src/services/hotel-conversation-notify.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const db = require('./db');
+
+/**
+ * Resolve hotel reservation + host/guest UUIDs for a TrustlessWork contract id.
+ * Returns null when the contract is not a hotel_industry escrow (or tables missing).
+ */
+async function resolveHotelEscrowParties(contractId) {
+  const result = await db.query(
+    `SELECT
+       et.id AS escrow_transaction_id,
+       et.reservation_id,
+       host_u.id AS host_id,
+       guest_u.id AS guest_id
+     FROM public.escrow_transactions et
+     LEFT JOIN public.escrow_transaction_users host_etu
+       ON host_etu.escrow_transaction_id = et.id
+      AND UPPER(host_etu.role) IN ('OWNER', 'HOST')
+     LEFT JOIN public.users host_u
+       ON host_u.email = host_etu.user_email
+     LEFT JOIN public.escrow_transaction_users guest_etu
+       ON guest_etu.escrow_transaction_id = et.id
+      AND UPPER(guest_etu.role) IN ('RENTER', 'GUEST')
+     LEFT JOIN public.users guest_u
+       ON guest_u.email = guest_etu.user_email
+     WHERE et.contract_id = $1
+     LIMIT 1`,
+    [contractId],
+  );
+
+  const row = result.rows[0];
+  if (!row?.reservation_id || !row?.host_id || !row?.guest_id) {
+    return null;
+  }
+
+  return {
+    reservationId: row.reservation_id,
+    hostId: row.host_id,
+    guestId: row.guest_id,
+    escrowTransactionId: row.escrow_transaction_id,
+  };
+}
+
+function webhookBaseUrl() {
+  if (process.env.WEBHOOK_BASE_URL) {
+    return process.env.WEBHOOK_BASE_URL.replace(/\/$/, '');
+  }
+  const port = process.env.WEBHOOK_PORT || process.env.PORT || 3001;
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Best-effort automated lifecycle message into the hotel conversation.
+ * Never throws — escrow status updates must not fail because of messaging.
+ */
+async function notifyHotelEscrowConversation({
+  contractId,
+  eventType,
+  body,
+}) {
+  try {
+    const parties = await resolveHotelEscrowParties(contractId);
+    if (!parties) {
+      console.log(
+        `[conversations/send] ⏭ skip automated message — no hotel escrow parties for contractId: ${contractId}`,
+      );
+      return;
+    }
+
+    const payload = {
+      reservationId: parties.reservationId,
+      hostId: parties.hostId,
+      guestId: parties.guestId,
+      senderId: parties.guestId,
+      body,
+      isAutomated: true,
+      eventType,
+      escrowTransactionId: parties.escrowTransactionId,
+    };
+
+    const res = await fetch(
+      `${webhookBaseUrl()}/api/hotel/conversations/send`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      console.error(
+        `[conversations/send] ❌ automated message failed — status: ${res.status} ${text}`,
+      );
+      return;
+    }
+
+    console.log(
+      `[conversations/send] ✅ automated message sent — event_type: ${eventType}`,
+    );
+  } catch (error) {
+    console.error(
+      `[conversations/send] ❌ automated message error — ${error.message}`,
+    );
+  }
+}
+
+module.exports = {
+  resolveHotelEscrowParties,
+  notifyHotelEscrowConversation,
+  webhookBaseUrl,
+};


### PR DESCRIPTION
## Summary
- Adds `POST /api/hotel/conversations/send` with find-or-create conversation + append message
- Wires `fund` / `release-funds` handlers to send best-effort automated lifecycle messages (`escrow_funded` / `escrow_completed`)
- Includes unit tests for validation and find-or-create behavior

Closes #490

## Test plan
- [ ] Apply prerequisite migrations/seeds from #488 / #489 (`dc_prep`)
- [ ] Start webhook (`node src/server.js`)
- [ ] `POST /api/hotel/conversations/send` with valid UUIDs + body → `{ conversationId, messageId, lastMessageAt }`
- [ ] Repeat with same reservation/host/guest and new body → same `conversationId`
- [ ] `POST /api/escrows/fund` for a hotel escrow with parties resolved → automated `escrow_funded` message (or skip log if no hotel parties)
- [ ] Confirm a failed notify does not fail the escrow fund/release response
- [ ] `cd webhook && npx jest --testPathPatterns=hotel/conversations`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hotel conversation messaging through a new send endpoint.
  * Supports creating or updating conversations with validation and automated-message details.
  * Automatically notifies hotel conversations when escrow deposits are funded or funds are released.
* **Bug Fixes**
  * Notification failures no longer interrupt successful escrow processing.
* **Tests**
  * Added coverage for invalid requests, new conversations, and existing conversation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->