### PR TITLE
Closes #479

### DIFF
--- a/webhook/src/middleware/__tests__/auth.middleware.test.js
+++ b/webhook/src/middleware/__tests__/auth.middleware.test.js
@@ -1,9 +1,15 @@
 const { authMiddleware } = require('../auth.middleware');
 const { getAuth } = require('firebase-admin/auth');
+const db = require('../../services/db');
 
 // Mock firebase-admin/auth
 jest.mock('firebase-admin/auth', () => ({
   getAuth: jest.fn()
+}));
+
+// Mock the db module so tests never hit a real Postgres connection.
+jest.mock('../../services/db', () => ({
+  query: jest.fn()
 }));
 
 describe('authMiddleware', () => {
@@ -17,6 +23,8 @@ describe('authMiddleware', () => {
     };
     next = jest.fn();
     jest.clearAllMocks();
+    // Default: no roles assigned unless a test overrides.
+    db.query.mockResolvedValue({ rows: [] });
   });
 
   it('should return 401 if Authorization header is missing', async () => {
@@ -44,20 +52,97 @@ describe('authMiddleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('should call next() and attach user if token is valid', async () => {
+  it('should call next() and attach user with roles from user_roles if token is valid', async () => {
     const mockUser = { uid: '123', email: 'test@example.com', name: 'Test User' };
     req.headers['authorization'] = 'Bearer valid-token';
     getAuth.mockReturnValue({
       verifyIdToken: jest.fn().mockResolvedValue(mockUser)
     });
+    db.query.mockResolvedValue({ rows: [{ name: 'host' }] });
 
     await authMiddleware(req, res, next);
     expect(req.user).toMatchObject({
       uid: mockUser.uid,
       email: mockUser.email,
       name: mockUser.name,
+      roles: ['host'],
+      role: 'host',
     });
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should default role to guest when the verified user has no roles', async () => {
+    const mockUser = { uid: '123', email: 'test@example.com', name: 'Test User' };
+    req.headers['authorization'] = 'Bearer valid-token';
+    getAuth.mockReturnValue({
+      verifyIdToken: jest.fn().mockResolvedValue(mockUser)
+    });
+    db.query.mockResolvedValue({ rows: [] });
+
+    await authMiddleware(req, res, next);
+    expect(req.user).toMatchObject({ roles: [], role: 'guest' });
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should not let custom claims clobber role/roles from user_roles', async () => {
+    // A stale/hostile `role` claim in the token must not override the DB lookup.
+    const mockUser = { uid: '123', email: 'test@example.com', role: 'admin', roles: ['admin'] };
+    req.headers['authorization'] = 'Bearer valid-token';
+    getAuth.mockReturnValue({
+      verifyIdToken: jest.fn().mockResolvedValue(mockUser)
+    });
+    db.query.mockResolvedValue({ rows: [{ name: 'guest' }] });
+
+    await authMiddleware(req, res, next);
+    expect(req.user).toMatchObject({ roles: ['guest'], role: 'guest' });
+    expect(next).toHaveBeenCalled();
+  });
+
+  describe('mock-token bypass', () => {
+    const OLD_ENV = process.env.NODE_ENV;
+
+    beforeEach(() => {
+      process.env.NODE_ENV = 'test';
+    });
+
+    afterAll(() => {
+      process.env.NODE_ENV = OLD_ENV;
+    });
+
+    it('should attach roles from user_roles for the mock-token test uid', async () => {
+      req.headers['authorization'] = 'Bearer mock-token';
+      req.headers['x-test-uid'] = 'host-user-001';
+      db.query.mockResolvedValue({ rows: [{ name: 'host' }] });
+
+      await authMiddleware(req, res, next);
+      expect(db.query).toHaveBeenCalledWith(expect.any(String), ['host-user-001']);
+      expect(req.user).toMatchObject({
+        uid: 'host-user-001',
+        roles: ['host'],
+        role: 'host',
+      });
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should default role to guest for a mock-token user with no roles', async () => {
+      req.headers['authorization'] = 'Bearer mock-token';
+      req.headers['x-test-uid'] = 'no-role-user-001';
+      db.query.mockResolvedValue({ rows: [] });
+
+      await authMiddleware(req, res, next);
+      expect(req.user).toMatchObject({ roles: [], role: 'guest' });
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return 500 if mock-token is used outside the test environment', async () => {
+      process.env.NODE_ENV = 'production';
+      req.headers['authorization'] = 'Bearer mock-token';
+
+      await authMiddleware(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(next).not.toHaveBeenCalled();
+    });
   });
 });

--- a/webhook/src/middleware/__tests__/require-role.test.js
+++ b/webhook/src/middleware/__tests__/require-role.test.js
@@ -45,6 +45,22 @@ describe('requireRole', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it('should permit a host-only route for a multi-role user (guest + host)', () => {
+    // Regression: a user assigned both roles must not be denied a host-only
+    // route just because the scalar `role` happened to resolve to 'guest'.
+    req.user = { role: 'guest', roles: ['guest', 'host'] };
+    requireRole(['host'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 for a multi-role user when none of their roles is allowed', () => {
+    req.user = { role: 'guest', roles: ['guest', 'host'] };
+    requireRole(['admin'])(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it('should treat an admin claim as the admin role', () => {
     req.user = { admin: true };
     requireRole(['admin'])(req, res, next);

--- a/webhook/src/middleware/__tests__/require-role.test.js
+++ b/webhook/src/middleware/__tests__/require-role.test.js
@@ -1,0 +1,61 @@
+const { requireRole } = require('../require-role');
+
+describe('requireRole', () => {
+  let req, res, next;
+
+  beforeEach(() => {
+    req = {};
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    next = jest.fn();
+  });
+
+  it('should return 401 when req.user is missing', () => {
+    requireRole(['host'])(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Unauthorized' })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should return 403 when a guest hits a host-only route', () => {
+    req.user = { role: 'guest' };
+    requireRole(['host'])(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Forbidden' })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should call next() when a guest is in the allowed roles', () => {
+    req.user = { role: 'guest' };
+    requireRole(['guest', 'host'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should call next() when a host is in the allowed roles', () => {
+    req.user = { role: 'host' };
+    requireRole(['guest', 'host'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should treat an admin claim as the admin role', () => {
+    req.user = { admin: true };
+    requireRole(['admin'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to guest when no role or admin claim is present', () => {
+    req.user = {};
+    requireRole(['guest'])(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/webhook/src/middleware/auth.middleware.js
+++ b/webhook/src/middleware/auth.middleware.js
@@ -6,8 +6,14 @@ const db = require('../services/db');
  *
  * Mirrors the query convention in `routes/auth/me.handler.js`: a user may hold
  * multiple roles, so `roles` is always an array. `role` is a convenience scalar
- * (the first assigned role, or `'guest'` when none are assigned) used by
- * `requireRole` and single-role response shapes.
+ * holding the highest-privilege assigned role (or `'guest'` when none are
+ * assigned), used for single-role response shapes.
+ *
+ * The query orders by an explicit privilege precedence so `roles[0]` — and any
+ * response derived from it — is deterministic. Without `ORDER BY`, PostgreSQL
+ * does not guarantee row order, which would make the scalar `role` (and the
+ * sync-user response) flap for multi-role users. Authorization decisions must
+ * still consider the full `roles` array, not just this scalar.
  *
  * @param {string} uid Firebase UID / users.id.
  * @returns {Promise<{ roles: string[], role: string }>}
@@ -17,7 +23,15 @@ async function resolveUserRole(uid) {
     `SELECT r.name
      FROM public.user_roles ur
      JOIN public.roles r ON r.id = ur.role_id
-     WHERE ur.user_id = $1`,
+     WHERE ur.user_id = $1
+     ORDER BY
+       CASE r.name
+         WHEN 'admin' THEN 0
+         WHEN 'host'  THEN 1
+         WHEN 'guest' THEN 2
+         ELSE 3
+       END,
+       r.name`,
     [uid]
   );
 

--- a/webhook/src/middleware/auth.middleware.js
+++ b/webhook/src/middleware/auth.middleware.js
@@ -1,7 +1,34 @@
 const { getAuth } = require('firebase-admin/auth');
+const db = require('../services/db');
 
 /**
- * Verifies a Firebase Bearer token and attaches `uid`, `email`, `name`, `role`, and `admin` to `req.user`.
+ * Resolves the roles assigned to a user from the `public.user_roles` join table.
+ *
+ * Mirrors the query convention in `routes/auth/me.handler.js`: a user may hold
+ * multiple roles, so `roles` is always an array. `role` is a convenience scalar
+ * (the first assigned role, or `'guest'` when none are assigned) used by
+ * `requireRole` and single-role response shapes.
+ *
+ * @param {string} uid Firebase UID / users.id.
+ * @returns {Promise<{ roles: string[], role: string }>}
+ */
+async function resolveUserRole(uid) {
+  const result = await db.query(
+    `SELECT r.name
+     FROM public.user_roles ur
+     JOIN public.roles r ON r.id = ur.role_id
+     WHERE ur.user_id = $1`,
+    [uid]
+  );
+
+  const roles = result.rows.map((row) => row.name);
+  return { roles, role: roles[0] ?? 'guest' };
+}
+
+/**
+ * Verifies a Firebase Bearer token and attaches `uid`, `email`, `name`, `role`,
+ * `roles`, and `admin` to `req.user`. Roles are sourced from `public.user_roles`
+ * (not Firebase custom claims) in both the test-bypass and verified-token paths.
  *
  * @param {import('express').Request} req
  * @param {import('express').Response} res
@@ -24,28 +51,33 @@ async function authMiddleware(req, res, next) {
   if (token === 'mock-token') {
     if (process.env.NODE_ENV !== 'test') {
       console.error('FATAL: mock-token used outside of test environment');
-      return res.status(500).json({ 
+      return res.status(500).json({
         error: 'Server configuration error',
-        message: 'mock-token not allowed in this environment' 
+        message: 'mock-token not allowed in this environment'
       });
     }
+    const uid = req.headers['x-test-uid'] || 'test-user-id';
+    const { roles, role } = await resolveUserRole(uid);
     req.user = {
-      uid: req.headers['x-test-uid'] || 'test-user-id',
-      email: req.headers['x-test-email'] || 'test@example.com'
+      uid,
+      email: req.headers['x-test-email'] || 'test@example.com',
+      roles,
+      role,
     };
     return next();
   }
 
   try {
     const decoded = await getAuth().verifyIdToken(token);
+    const { roles, role } = await resolveUserRole(decoded.uid);
     req.user = {
       uid: decoded.uid,
       email: decoded.email,
       name: decoded.name,
-      role: decoded.role,
       admin: decoded.admin === true,
-      name:  decoded.name,
       ...decoded, // Include all custom claims
+      roles, // role/roles from user_roles win over any custom claims
+      role,
     };
     next();
   } catch (error) {
@@ -57,4 +89,4 @@ async function authMiddleware(req, res, next) {
   }
 }
 
-module.exports = { authMiddleware, authenticateFirebase: authMiddleware };
+module.exports = { authMiddleware, authenticateFirebase: authMiddleware, resolveUserRole };

--- a/webhook/src/middleware/require-role.js
+++ b/webhook/src/middleware/require-role.js
@@ -1,6 +1,6 @@
 /**
  * Role-based authorization factory. Expects `req.user.role` and/or `req.user.admin`
- * (set by `authenticateFirebase` or `authMiddleware` from Firebase token / custom claims).
+ * (set by `authenticateFirebase` or `authMiddleware` from the `user_roles` lookup).
  *
  * @param {string[]} allowedRoles Roles permitted for the route (e.g. `['admin']`).
  * @returns {import('express').RequestHandler}
@@ -15,8 +15,6 @@ function requireRole(allowedRoles) {
     }
 
     const userRole = req.user.role || (req.user.admin ? 'admin' : 'guest');
-    // Extract role from custom claims (assuming 'role' or 'admin' claim)
-    const userRole = req.user.role || (req.user.admin ? 'admin' : null);
 
     if (!userRole || !allowedRoles.includes(userRole)) {
       return res.status(403).json({

--- a/webhook/src/middleware/require-role.js
+++ b/webhook/src/middleware/require-role.js
@@ -1,6 +1,11 @@
 /**
- * Role-based authorization factory. Expects `req.user.role` and/or `req.user.admin`
- * (set by `authenticateFirebase` or `authMiddleware` from the `user_roles` lookup).
+ * Role-based authorization factory. Expects `req.user.roles` (array, set by
+ * `authenticateFirebase` / `authMiddleware` from the `user_roles` lookup) and/or
+ * the scalar `req.user.role` / `req.user.admin` fallbacks.
+ *
+ * Authorization succeeds when *any* of the user's assigned roles is allowed — a
+ * multi-role user (e.g. `['guest', 'host']`) must not be denied a `host`-only
+ * route just because the scalar `role` resolved to `guest`.
  *
  * @param {string[]} allowedRoles Roles permitted for the route (e.g. `['admin']`).
  * @returns {import('express').RequestHandler}
@@ -14,9 +19,16 @@ function requireRole(allowedRoles) {
       });
     }
 
-    const userRole = req.user.role || (req.user.admin ? 'admin' : 'guest');
+    // Prefer the full roles array; fall back to the scalar role / admin claim,
+    // defaulting to 'guest' when nothing is assigned.
+    const userRoles =
+      Array.isArray(req.user.roles) && req.user.roles.length > 0
+        ? req.user.roles
+        : [req.user.role || (req.user.admin ? 'admin' : 'guest')];
 
-    if (!userRole || !allowedRoles.includes(userRole)) {
+    const isAllowed = userRoles.some((role) => allowedRoles.includes(role));
+
+    if (!isAllowed) {
       return res.status(403).json({
         error: 'Forbidden',
         message: 'Insufficient permissions or role not assigned',

--- a/webhook/src/routes/auth/sync-user.handler.js
+++ b/webhook/src/routes/auth/sync-user.handler.js
@@ -62,6 +62,7 @@ const syncUserHandler = async (req, res) => {
       user: {
         id: user.id,
         email: user.email,
+        role: req.user.role,
         last_seen: user.last_seen ?? user.updated_at,
       },
     });


### PR DESCRIPTION
## fix(webhook): resolve duplicate const in require-role.js and wire role lookup from user_roles

Closes #479

### Problem

`require-role.js` declared `const userRole` twice in the same scope — a `SyntaxError` at
runtime that crashed anything requiring the middleware. Separately, the middleware and
`auth.middleware.js` were designed around Firebase custom claims (`req.user.role`) that
SafeTrust never actually sets. Roles live in `public.user_roles`, so every role-protected
route was silently falling through to `403`.

### What changed

- **`require-role.js`** — removed the duplicate `const userRole` declaration. Fallback for an
  unset role is now `'guest'` instead of `null`.
- **`auth.middleware.js`** — added `resolveUserRole(uid)`, which queries
  `user_roles JOIN roles` (same pattern already used in `me.handler.js`) and returns both
  `roles` (array, since a user can hold more than one role) and `role` (first assigned role,
  or `'guest'`). This is called from **both** code paths in the middleware — the
  `mock-token` test bypass and the real `verifyIdToken` success path — not just the latter.
  That distinction matters: karate's auth helper always sends the literal string
  `'mock-token'`, so if the DB lookup only lived in the `verifyIdToken` branch, role would
  never populate under the karate suite at all.
- Roles from the DB are attached **after** the `...decoded` custom-claims spread, so a stale
  or hostile `role`/`roles` claim baked into a token can't override what the DB says. Covered
  by a dedicated test.
- Removed a duplicate `name:` key left over in the same object literal.
- **`sync-user.handler.js`** — added `role: req.user.role` to the response payload.

### Scope note

`sync-user.handler.js` isn't in the issue's listed files, but I touched it anyway: the
acceptance criterion `POST /api/auth/sync-user returns { user: { id, email, role } }` is
unreachable without it, since `role` only exists on `req.user` once middleware resolves it.
Flagging this explicitly rather than letting an extra file show up unexplained in the diff.

### Tests

- `require-role.test.js` (new) — covers the acceptance criteria directly: 401 with no
  `req.user`, 403 for a guest hitting a host-only route, 200/`next()` for guest or host on a
  shared route, admin-claim handling, and the no-role → guest fallback.
- `auth.middleware.test.js` — added `jest.mock('../../services/db')` so the existing suite
  doesn't try to hit a real Postgres connection now that a DB call is in the middleware.
  Added cases for: role/roles attached on a valid token, guest fallback when no roles exist,
  custom claims not clobbering the DB-resolved role, and both mock-token scenarios
  (role attached, guest fallback, and the existing 500-outside-test-env case).

### Verification

| Check | Result |
|---|---|
| `node -e "require('./src/middleware/require-role.js')"` | ✅ loads, no `SyntaxError` |
| `npx jest` (full suite) | ✅ passing |
| Karate (`roles.feature`, `sync-user.feature`) via `docker-compose-test.yml` | ✅ passing — ran locally against a real seeded `user_roles` table, exercising the mock-token → DB-lookup path end to end |

### Acceptance criteria

- [x] `node src/server.js` starts without `SyntaxError`
- [x] `POST /api/auth/sync-user` with a valid Firebase token returns `{ user: { id, email, role } }`
- [x] `requireRole(['host'])` returns 403 when user has `guest` role
- [x] `requireRole(['guest', 'host'])` returns 200 when user has either role
- [x] Karate test — the issue references a nonexistent `auth/middleware.feature`; the actual relevant coverage, `tests/karate/features/auth/roles.feature` and `sync-user.feature`, both pass locally via `docker-compose-test.yml`.
- [x] No `const` redeclaration in `require-role.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User roles are now resolved from the application’s role assignments and included in authenticated user details.
  - User synchronization responses now include the user’s assigned role.
  - Users without an assigned role default to `guest`.
- **Bug Fixes**
  - Token-provided roles no longer override application-assigned roles.
  - Mock authentication is restricted to test environments.
  - Role-based access now handles missing roles consistently.
- **Tests**
  - Added coverage for authentication, role resolution, authorization, fallback roles, and mock-auth behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->