### PR TITLE
feat(migration): add conversations and messages tables — host-guest communication infrastructure

### DIFF
--- a/migrations/safetrust/1778000000000_create_conversations/down.sql
+++ b/migrations/safetrust/1778000000000_create_conversations/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS conversations_update_last_message ON public.messages;
+DROP FUNCTION IF EXISTS public.update_conversation_last_message();
+DROP TABLE IF EXISTS public.conversations;

--- a/migrations/safetrust/1778000000000_create_conversations/up.sql
+++ b/migrations/safetrust/1778000000000_create_conversations/up.sql
@@ -23,9 +23,9 @@ CREATE TABLE public.conversations (
 );
 
 CREATE INDEX idx_conversations_host
-  ON public.conversations(host_id, last_message_at DESC);
+  ON public.conversations(host_id, last_message_at DESC NULLS LAST);
 CREATE INDEX idx_conversations_guest
-  ON public.conversations(guest_id, last_message_at DESC);
+  ON public.conversations(guest_id, last_message_at DESC NULLS LAST);
 CREATE INDEX idx_conversations_apartment
   ON public.conversations(apartment_id);
 CREATE INDEX idx_conversations_escrow
@@ -34,7 +34,15 @@ CREATE INDEX idx_conversations_escrow
 
 -- Auto-update last_message_at when a new message is inserted
 CREATE OR REPLACE FUNCTION public.update_conversation_last_message()
-RETURNS TRIGGER AS $$ BEGIN   UPDATE public.conversations   SET last_message_at = NEW.created_at,       updated_at = NOW()   WHERE id = NEW.conversation_id;   RETURN NEW; END; $$ LANGUAGE plpgsql;
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE public.conversations
+  SET last_message_at = GREATEST(COALESCE(last_message_at, NEW.created_at), NEW.created_at),
+      updated_at = NOW()
+  WHERE id = NEW.conversation_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
 
 COMMENT ON TABLE public.conversations IS
   'One thread per apartment per host-guest pair. Links to escrow for lifecycle messaging.';

--- a/migrations/safetrust/1778000000000_create_conversations/up.sql
+++ b/migrations/safetrust/1778000000000_create_conversations/up.sql
@@ -1,0 +1,44 @@
+-- ============================================================================
+-- conversations: one thread per apartment per host-guest pair.
+-- Linked to trustless_work_escrows so escrow lifecycle events can be
+-- associated with the correct conversation thread automatically.
+-- ============================================================================
+CREATE TABLE public.conversations (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  apartment_id      UUID NOT NULL REFERENCES public.apartments(id) ON DELETE CASCADE,
+  host_id           TEXT NOT NULL REFERENCES public.users(id),
+  guest_id          TEXT NOT NULL REFERENCES public.users(id),
+  -- Optional escrow link — set when booking moves to funded status
+  escrow_id         UUID REFERENCES public.trustless_work_escrows(id) ON DELETE SET NULL,
+  status            VARCHAR(50) NOT NULL DEFAULT 'active'
+                      CHECK (status IN ('active', 'archived', 'blocked')),
+  -- Denormalised for efficient inbox sort — updated by trigger on message INSERT
+  last_message_at   TIMESTAMP WITH TIME ZONE,
+  created_at        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  tenant_id         VARCHAR(255) NOT NULL DEFAULT 'safetrust',
+  -- One conversation per apartment per host-guest pair
+  CONSTRAINT unique_conversation UNIQUE (apartment_id, host_id, guest_id),
+  CONSTRAINT host_guest_different CHECK (host_id != guest_id)
+);
+
+CREATE INDEX idx_conversations_host
+  ON public.conversations(host_id, last_message_at DESC);
+CREATE INDEX idx_conversations_guest
+  ON public.conversations(guest_id, last_message_at DESC);
+CREATE INDEX idx_conversations_apartment
+  ON public.conversations(apartment_id);
+CREATE INDEX idx_conversations_escrow
+  ON public.conversations(escrow_id)
+  WHERE escrow_id IS NOT NULL;
+
+-- Auto-update last_message_at when a new message is inserted
+CREATE OR REPLACE FUNCTION public.update_conversation_last_message()
+RETURNS TRIGGER AS $$ BEGIN   UPDATE public.conversations   SET last_message_at = NEW.created_at,       updated_at = NOW()   WHERE id = NEW.conversation_id;   RETURN NEW; END; $$ LANGUAGE plpgsql;
+
+COMMENT ON TABLE public.conversations IS
+  'One thread per apartment per host-guest pair. Links to escrow for lifecycle messaging.';
+COMMENT ON COLUMN public.conversations.escrow_id IS
+  'Set when booking is confirmed and escrow is funded — enables automated lifecycle messages.';
+COMMENT ON COLUMN public.conversations.last_message_at IS
+  'Denormalised from messages — updated by trigger for efficient inbox ordering.';

--- a/migrations/safetrust/1778000000001_create_messages/down.sql
+++ b/migrations/safetrust/1778000000001_create_messages/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER IF EXISTS conversations_update_last_message ON public.messages;
+DROP TABLE IF EXISTS public.messages;

--- a/migrations/safetrust/1778000000001_create_messages/up.sql
+++ b/migrations/safetrust/1778000000001_create_messages/up.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- messages: individual messages within a conversation.
+-- Supports both manual messages (is_automated = false) and automated
+-- escrow lifecycle notifications (is_automated = true, event_type set).
+--
+-- Automated event_type values (for reference):
+--   'booking_inquiry'       — guest asks host a question pre-booking
+--   'booking_confirmed'     — escrow deployed on Stellar
+--   'escrow_funded'         — tenant deposit confirmed on Stellar
+--   'milestone_approved'    — service provider marks milestone complete
+--   'funds_released'        — escrow released to owner
+--   'dispute_opened'        — escrow disputed
+--   'dispute_resolved'      — dispute resolved
+--   'check_in_reminder'     — automated 24h before available_from date
+--   'checkout_reminder'     — automated 24h before available_until date
+-- ============================================================================
+CREATE TABLE public.messages (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id   UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
+  sender_id         TEXT NOT NULL REFERENCES public.users(id),
+  body              TEXT NOT NULL
+                      CHECK (char_length(body) > 0 AND char_length(body) <= 4000),
+  -- Automated message metadata
+  is_automated      BOOLEAN NOT NULL DEFAULT false,
+  event_type        VARCHAR(100),
+  -- Read tracking: NULL = unread, timestamp = when it was read
+  read_at           TIMESTAMP WITH TIME ZONE,
+  created_at        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  tenant_id         VARCHAR(255) NOT NULL DEFAULT 'safetrust',
+  -- event_type only valid on automated messages
+  CONSTRAINT event_type_requires_automated
+    CHECK (event_type IS NULL OR is_automated = true)
+);
+
+-- Primary access pattern: all messages in a conversation, chronological
+CREATE INDEX idx_messages_conversation
+  ON public.messages(conversation_id, created_at ASC);
+
+-- Unread count per conversation — partial index, small footprint
+CREATE INDEX idx_messages_unread
+  ON public.messages(conversation_id, sender_id)
+  WHERE read_at IS NULL;
+
+-- Automated message lookup — for deduplication and event history
+CREATE INDEX idx_messages_event_type
+  ON public.messages(conversation_id, event_type)
+  WHERE is_automated = true;
+
+CREATE TRIGGER conversations_update_last_message
+  AFTER INSERT ON public.messages
+  FOR EACH ROW EXECUTE FUNCTION public.update_conversation_last_message();
+
+COMMENT ON TABLE public.messages IS
+  'Individual messages within a conversation. Supports manual and automated escrow lifecycle messages.';
+COMMENT ON COLUMN public.messages.is_automated IS
+  'True for system-generated messages triggered by escrow lifecycle events.';
+COMMENT ON COLUMN public.messages.event_type IS
+  'Escrow lifecycle event that triggered this message. NULL for manual messages.';
+COMMENT ON COLUMN public.messages.read_at IS
+  'NULL means unread. Set to NOW() when recipient opens the conversation.';

--- a/migrations/safetrust/1778000000001_create_messages/up.sql
+++ b/migrations/safetrust/1778000000001_create_messages/up.sql
@@ -19,17 +19,30 @@ CREATE TABLE public.messages (
   conversation_id   UUID NOT NULL REFERENCES public.conversations(id) ON DELETE CASCADE,
   sender_id         TEXT NOT NULL REFERENCES public.users(id),
   body              TEXT NOT NULL
-                      CHECK (char_length(body) > 0 AND char_length(body) <= 4000),
+                      CHECK (char_length(trim(body)) > 0 AND char_length(body) <= 4000),
   -- Automated message metadata
   is_automated      BOOLEAN NOT NULL DEFAULT false,
   event_type        VARCHAR(100),
   -- Read tracking: NULL = unread, timestamp = when it was read
   read_at           TIMESTAMP WITH TIME ZONE,
-  created_at        TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at        TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   tenant_id         VARCHAR(255) NOT NULL DEFAULT 'safetrust',
-  -- event_type only valid on automated messages
+  -- event_type only valid on automated messages and restricted to valid lifecycle events
   CONSTRAINT event_type_requires_automated
-    CHECK (event_type IS NULL OR is_automated = true)
+    CHECK (
+      (is_automated = false AND event_type IS NULL) OR
+      (is_automated = true AND event_type IS NOT NULL AND event_type IN (
+        'booking_inquiry',
+        'booking_confirmed',
+        'escrow_funded',
+        'milestone_approved',
+        'funds_released',
+        'dispute_opened',
+        'dispute_resolved',
+        'check_in_reminder',
+        'checkout_reminder'
+      ))
+    )
 );
 
 -- Primary access pattern: all messages in a conversation, chronological

--- a/webhook/src/routes/hotel/conversations/__tests__/send.handler.test.js
+++ b/webhook/src/routes/hotel/conversations/__tests__/send.handler.test.js
@@ -15,7 +15,7 @@ function makeResponse() {
 }
 
 const ids = {
-  reservationId: '11111111-1111-4111-8111-111111111111',
+  apartmentId: '11111111-1111-4111-8111-111111111111',
   hostId: '22222222-2222-4222-8222-222222222222',
   guestId: '33333333-3333-4333-8333-333333333333',
   senderId: '33333333-3333-4333-8333-333333333333',
@@ -29,7 +29,7 @@ describe('sendHotelConversationHandler', () => {
   });
 
   it('returns 400 when required fields are missing', async () => {
-    const req = { body: { reservationId: ids.reservationId } };
+    const req = { body: { apartmentId: ids.apartmentId } };
     const res = makeResponse();
 
     await sendHotelConversationHandler(req, res);
@@ -61,6 +61,11 @@ describe('sendHotelConversationHandler', () => {
     await sendHotelConversationHandler(req, res);
 
     expect(db.query).toHaveBeenCalledTimes(2);
+    expect(db.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('apartment_id'),
+      [ids.apartmentId, ids.hostId, ids.guestId],
+    );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       conversationId: ids.conversationId,
@@ -71,6 +76,7 @@ describe('sendHotelConversationHandler', () => {
 
   it('creates a conversation when none exists', async () => {
     const createdAt = new Date('2026-07-27T00:00:00.000Z');
+    const escrowId = '66666666-6666-4666-8666-666666666666';
     db.query
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: ids.conversationId }] })
@@ -82,7 +88,7 @@ describe('sendHotelConversationHandler', () => {
       body: {
         ...ids,
         body: 'First message',
-        escrowTransactionId: '66666666-6666-4666-8666-666666666666',
+        escrowId,
       },
     };
     const res = makeResponse();
@@ -90,6 +96,11 @@ describe('sendHotelConversationHandler', () => {
     await sendHotelConversationHandler(req, res);
 
     expect(db.query).toHaveBeenCalledTimes(3);
+    expect(db.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/INSERT INTO public\.conversations[\s\S]*apartment_id[\s\S]*escrow_id/),
+      [ids.apartmentId, ids.hostId, ids.guestId, escrowId],
+    );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       conversationId: ids.conversationId,

--- a/webhook/src/routes/hotel/conversations/send.handler.js
+++ b/webhook/src/routes/hotel/conversations/send.handler.js
@@ -81,12 +81,20 @@ async function sendHotelConversationHandler(req, res) {
     let conversationId;
 
     const existing = await db.query(
-      `SELECT id FROM public.conversations
+      `SELECT id, escrow_id FROM public.conversations
        WHERE apartment_id = $1 AND host_id = $2 AND guest_id = $3`,
       [apartmentId, hostId, guestId],
     );
 
     conversationId = existing.rows[0]?.id;
+
+    // Fix: Persist the provided escrowId if the existing conversation has a NULL escrow_id
+    if (conversationId && escrowId && existingRow.escrow_id == null) {
+      await db.query(
+        `UPDATE public.conversations SET escrow_id = $1 WHERE id = $2`,
+        [escrowId, conversationId],
+      );
+    }
 
     if (!conversationId) {
       try {
@@ -112,6 +120,14 @@ async function sendHotelConversationHandler(req, res) {
             [apartmentId, hostId, guestId],
           );
           conversationId = again.rows[0]?.id;
+
+          // Secondary check in case the race condition hit an unlinked conversation
+          if (conversationId && escrowId && again.rows[0].escrow_id == null) {
+             await db.query(
+              `UPDATE public.conversations SET escrow_id = $1 WHERE id = $2`,
+              [escrowId, conversationId],
+            );
+          }
         } else {
           throw err;
         }

--- a/webhook/src/routes/hotel/conversations/send.handler.js
+++ b/webhook/src/routes/hotel/conversations/send.handler.js
@@ -5,22 +5,22 @@ const db = require('../../../services/db');
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const REQUIRED = ['reservationId', 'hostId', 'guestId', 'senderId', 'body'];
+const REQUIRED = ['apartmentId', 'hostId', 'guestId', 'senderId', 'body'];
 
 /**
- * Find-or-create a hotel conversation for a reservation/host/guest triple,
+ * Find-or-create a conversation for an apartment/host/guest triple,
  * then append a message. DB trigger updates conversations.last_message_at.
  */
 async function sendHotelConversationHandler(req, res) {
   const {
-    reservationId,
+    apartmentId,
     hostId,
     guestId,
     senderId,
     body,
     isAutomated = false,
     eventType = null,
-    escrowTransactionId = null,
+    escrowId = null,
   } = req.body || {};
 
   const missing = REQUIRED.filter((key) => {
@@ -38,7 +38,7 @@ async function sendHotelConversationHandler(req, res) {
   }
 
   for (const [label, value] of [
-    ['reservationId', reservationId],
+    ['apartmentId', apartmentId],
     ['hostId', hostId],
     ['guestId', guestId],
     ['senderId', senderId],
@@ -49,13 +49,13 @@ async function sendHotelConversationHandler(req, res) {
   }
 
   if (
-    escrowTransactionId != null &&
-    escrowTransactionId !== '' &&
-    !UUID_RE.test(String(escrowTransactionId))
+    escrowId != null &&
+    escrowId !== '' &&
+    !UUID_RE.test(String(escrowId))
   ) {
     return res
       .status(400)
-      .json({ error: 'escrowTransactionId must be a valid UUID or null' });
+      .json({ error: 'escrowId must be a valid UUID or null' });
   }
 
   const text = String(body).trim();
@@ -82,8 +82,8 @@ async function sendHotelConversationHandler(req, res) {
 
     const existing = await db.query(
       `SELECT id FROM public.conversations
-       WHERE reservation_id = $1 AND host_id = $2 AND guest_id = $3`,
-      [reservationId, hostId, guestId],
+       WHERE apartment_id = $1 AND host_id = $2 AND guest_id = $3`,
+      [apartmentId, hostId, guestId],
     );
 
     conversationId = existing.rows[0]?.id;
@@ -92,24 +92,24 @@ async function sendHotelConversationHandler(req, res) {
       try {
         const created = await db.query(
           `INSERT INTO public.conversations
-             (reservation_id, host_id, guest_id, escrow_transaction_id)
+             (apartment_id, host_id, guest_id, escrow_id)
            VALUES ($1, $2, $3, $4)
            RETURNING id`,
           [
-            reservationId,
+            apartmentId,
             hostId,
             guestId,
-            escrowTransactionId || null,
+            escrowId || null,
           ],
         );
         conversationId = created.rows[0].id;
       } catch (err) {
-        // Concurrent find-or-create race — unique_hotel_conversation
+        // Concurrent find-or-create race — unique_conversation
         if (err.code === '23505') {
           const again = await db.query(
             `SELECT id FROM public.conversations
-             WHERE reservation_id = $1 AND host_id = $2 AND guest_id = $3`,
-            [reservationId, hostId, guestId],
+             WHERE apartment_id = $1 AND host_id = $2 AND guest_id = $3`,
+            [apartmentId, hostId, guestId],
           );
           conversationId = again.rows[0]?.id;
         } else {

--- a/webhook/src/services/hotel-conversation-notify.js
+++ b/webhook/src/services/hotel-conversation-notify.js
@@ -10,10 +10,14 @@ async function resolveHotelEscrowParties(contractId) {
   const result = await db.query(
     `SELECT
        et.id AS escrow_transaction_id,
-       et.reservation_id,
+       r.apartment_id,
        host_u.id AS host_id,
        guest_u.id AS guest_id
      FROM public.escrow_transactions et
+     JOIN hotel.reservations res
+       ON et.reservation_id = res.id
+     JOIN hotel.rooms r 
+      ON res.room_id = r.id
      LEFT JOIN public.escrow_transaction_users host_etu
        ON host_etu.escrow_transaction_id = et.id
       AND UPPER(host_etu.role) IN ('OWNER', 'HOST')
@@ -30,14 +34,14 @@ async function resolveHotelEscrowParties(contractId) {
   );
 
   const row = result.rows[0];
-  if (!row?.reservation_id || !row?.host_id || !row?.guest_id) {
+  if (!row?.apartment_id || !row?.host_id || !row?.guest_id) {
     return null;
   }
 
   // Map hotel reservation/escrow rows onto the safetrust conversations contract
   // (apartment_id + escrow_id on public.conversations).
   return {
-    apartmentId: row.reservation_id,
+    apartmentId: row.apartment_id,
     hostId: row.host_id,
     guestId: row.guest_id,
     escrowId: row.escrow_transaction_id,

--- a/webhook/src/services/hotel-conversation-notify.js
+++ b/webhook/src/services/hotel-conversation-notify.js
@@ -34,11 +34,13 @@ async function resolveHotelEscrowParties(contractId) {
     return null;
   }
 
+  // Map hotel reservation/escrow rows onto the safetrust conversations contract
+  // (apartment_id + escrow_id on public.conversations).
   return {
-    reservationId: row.reservation_id,
+    apartmentId: row.reservation_id,
     hostId: row.host_id,
     guestId: row.guest_id,
-    escrowTransactionId: row.escrow_transaction_id,
+    escrowId: row.escrow_transaction_id,
   };
 }
 
@@ -69,14 +71,14 @@ async function notifyHotelEscrowConversation({
     }
 
     const payload = {
-      reservationId: parties.reservationId,
+      apartmentId: parties.apartmentId,
       hostId: parties.hostId,
       guestId: parties.guestId,
       senderId: parties.guestId,
       body,
       isAutomated: true,
       eventType,
-      escrowTransactionId: parties.escrowTransactionId,
+      escrowId: parties.escrowId,
     };
 
     const res = await fetch(


### PR DESCRIPTION
- Closes #481

---

## Summary
Implements the database messaging layer foundation within the `safetrust` tenant schema to support host-guest communication across the booking lifecycle.

## Changes
- **`1778000000000_create_conversations`**: Creates `public.conversations` table (thread per apartment/host/guest pair, optional escrow link) and defines `update_conversation_last_message()` trigger function.
- **`1778000000001_create_messages`**: Creates `public.messages` table (supports manual and automated escrow lifecycle events, read tracking) and binds trigger `conversations_update_last_message` AFTER INSERT.

## Verification
- Ran a validation script against all acceptance criteria from issue #481
```sql
-- 1 & 3. Select from conversations and messages
SELECT COUNT(*) AS conversations_count FROM public.conversations;
SELECT COUNT(*) AS messages_count FROM public.messages;

-- Create sample users if needed for test
INSERT INTO public.users (id, firebase_uid, email) VALUES ('user_host_1', 'uid_host_1', 'host@example.com') ON CONFLICT DO NOTHING;
INSERT INTO public.users (id, firebase_uid, email) VALUES ('user_guest_1', 'uid_guest_1', 'guest@example.com') ON CONFLICT DO NOTHING;

DO $$
DECLARE
  v_apartment_id UUID;
  v_conv_id UUID;
  v_msg_id UUID;
  v_last_msg_before TIMESTAMPTZ;
  v_last_msg_after TIMESTAMPTZ;
BEGIN
  -- Clean up test records from previous test runs to make test idempotent
  DELETE FROM public.conversations WHERE host_id = 'user_host_1' AND guest_id = 'user_guest_1';

  SELECT id INTO v_apartment_id FROM public.apartments LIMIT 1;
  IF v_apartment_id IS NULL THEN
    v_apartment_id := gen_random_uuid();
    INSERT INTO public.apartments (id, owner_id, name, price, warranty_deposit, coordinates, address, available_from)
    VALUES (v_apartment_id, 'user_host_1', 'Test Apartment', 100.00, 50.00, point(0,0), '{}'::jsonb, NOW());
  END IF;

  -- 4. Observe that trying to send a message to yourself fails (host_id != guest_id check)
  BEGIN
    INSERT INTO public.conversations (apartment_id, host_id, guest_id, tenant_id)
    VALUES (v_apartment_id, 'user_host_1', 'user_host_1', 'safetrust');
    RAISE EXCEPTION 'TEST FAILED: host_id == guest_id should have failed';
  EXCEPTION WHEN check_violation THEN
    RAISE NOTICE 'TEST PASSED: host_id == guest_id correctly failed check constraint';
  END;

  -- Create valid conversation
  INSERT INTO public.conversations (apartment_id, host_id, guest_id, tenant_id)
  VALUES (v_apartment_id, 'user_host_1', 'user_guest_1', 'safetrust')
  RETURNING id INTO v_conv_id;
  RAISE NOTICE 'Created conversation %', v_conv_id;

  -- 5. Observe that trying to create duplicate thread for same apartment/host/guest fails
  BEGIN
    INSERT INTO public.conversations (apartment_id, host_id, guest_id, tenant_id)
    VALUES (v_apartment_id, 'user_host_1', 'user_guest_1', 'safetrust');
    RAISE EXCEPTION 'TEST FAILED: Duplicate conversation should have failed';
  EXCEPTION WHEN unique_violation THEN
    RAISE NOTICE 'TEST PASSED: Duplicate conversation correctly failed unique constraint';
  END;

  -- 7. Observe that trying to set event_type on non-automated message (is_automated = false) fails
  BEGIN
    INSERT INTO public.messages (conversation_id, sender_id, body, is_automated, event_type, tenant_id)
    VALUES (v_conv_id, 'user_guest_1', 'Hello Host', false, 'booking_inquiry', 'safetrust');
    RAISE EXCEPTION 'TEST FAILED: Non-automated message with event_type should have failed';
  EXCEPTION WHEN check_violation THEN
    RAISE NOTICE 'TEST PASSED: Non-automated message with event_type correctly failed check constraint';
  END;

  -- 6. Observe that inserting a message triggers update of last_message_at on the associated conversation
  SELECT last_message_at INTO v_last_msg_before FROM public.conversations WHERE id = v_conv_id;
  
  INSERT INTO public.messages (conversation_id, sender_id, body, is_automated, tenant_id)
  VALUES (v_conv_id, 'user_guest_1', 'Hello Host! Is this available?', false, 'safetrust')
  RETURNING id INTO v_msg_id;

  SELECT last_message_at INTO v_last_msg_after FROM public.conversations WHERE id = v_conv_id;

  IF v_last_msg_after IS NULL THEN
    RAISE EXCEPTION 'TEST FAILED: last_message_at was not updated by trigger';
  ELSE
    RAISE NOTICE 'TEST PASSED: trigger updated last_message_at to %', v_last_msg_after;
  END IF;

  -- Insert automated message with event_type successfully
  INSERT INTO public.messages (conversation_id, sender_id, body, is_automated, event_type, tenant_id)
  VALUES (v_conv_id, 'user_host_1', 'Automated: Booking inquiry received', true, 'booking_inquiry', 'safetrust');
  RAISE NOTICE 'TEST PASSED: Automated message with event_type inserted successfully';

END $$;
```

<img width="857" height="482" alt="image" src="https://github.com/user-attachments/assets/67368a34-d667-4e20-af83-50e50e04a7b7" />



Closes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added apartment-based conversation threads for host/guest pairs, with active/archived/blocked status and optional escrow association.
  * Added support for manual messages and automated escrow/reminder events, with read tracking and inbox-friendly indexing for fast retrieval.
* **Bug Fixes**
  * Conversation previews now reliably reflect the latest message without ever moving the “last message” timestamp backward.
  * Automated messages are restricted to supported event types, and message text must contain non-whitespace content.
* **Tests**
  * Updated hotel conversation send handler tests to use `apartmentId`/`escrowId` and revised query/insert expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->