### PR TITLE
chore: add conversation and message seed data

### DIFF
--- a/seeds/safetrust/1778100000000_conversations_seed.sql
+++ b/seeds/safetrust/1778100000000_conversations_seed.sql
@@ -13,6 +13,10 @@ WHERE conversation_id IN (
       '550e8400-e29b-41d4-a716-446655440001'::uuid,
       '550e8400-e29b-41d4-a716-446655440002'::uuid
     )
+    AND id IN (
+      '00000000-0000-4000-8000-000000000001'::uuid,
+      '00000000-0000-4000-8000-000000000002'::uuid
+    )
 );
 
 DELETE FROM public.conversations
@@ -20,6 +24,10 @@ WHERE tenant_id = 'safetrust'
   AND apartment_id IN (
     '550e8400-e29b-41d4-a716-446655440001'::uuid,
     '550e8400-e29b-41d4-a716-446655440002'::uuid
+  )
+  AND id IN (
+    '00000000-0000-4000-8000-000000000001'::uuid,
+    '00000000-0000-4000-8000-000000000002'::uuid
   );
 
 -- Conversation 1: pre-booking inquiry (no escrow yet).

--- a/seeds/safetrust/1778100000000_conversations_seed.sql
+++ b/seeds/safetrust/1778100000000_conversations_seed.sql
@@ -1,0 +1,141 @@
+-- ============================================================================
+-- Seed conversations and messages for local development and the SCF demo.
+-- Depends on: user, apartments, and trustless_work_escrows seeds.
+-- Idempotent: delete the demo threads before inserting them again.
+-- ============================================================================
+
+DELETE FROM public.messages
+WHERE conversation_id IN (
+  SELECT id
+  FROM public.conversations
+  WHERE tenant_id = 'safetrust'
+    AND apartment_id IN (
+      '550e8400-e29b-41d4-a716-446655440001'::uuid,
+      '550e8400-e29b-41d4-a716-446655440002'::uuid
+    )
+);
+
+DELETE FROM public.conversations
+WHERE tenant_id = 'safetrust'
+  AND apartment_id IN (
+    '550e8400-e29b-41d4-a716-446655440001'::uuid,
+    '550e8400-e29b-41d4-a716-446655440002'::uuid
+  );
+
+-- Conversation 1: pre-booking inquiry (no escrow yet).
+INSERT INTO public.conversations (
+  id,
+  apartment_id,
+  host_id,
+  guest_id,
+  status,
+  tenant_id
+) VALUES (
+  '00000000-0000-4000-8000-000000000001'::uuid,
+  '550e8400-e29b-41d4-a716-446655440001'::uuid,
+  'demo-owner-uid-002',
+  'demo-tenant-uid-001',
+  'active',
+  'safetrust'
+);
+
+INSERT INTO public.messages (
+  conversation_id,
+  sender_id,
+  body,
+  is_automated,
+  read_at,
+  tenant_id
+) VALUES
+  (
+    '00000000-0000-4000-8000-000000000001'::uuid,
+    'demo-tenant-uid-001',
+    'Hola, me interesa el apartamento. ¿Está disponible a partir del 1 de agosto?',
+    false,
+    NOW() - INTERVAL '2 hours',
+    'safetrust'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000001'::uuid,
+    'demo-owner-uid-002',
+    'Hola! Sí, está disponible desde el 1 de agosto. El depósito es de $2,400 USDC via SafeTrust escrow.',
+    false,
+    NOW() - INTERVAL '1 hour',
+    'safetrust'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000001'::uuid,
+    'demo-tenant-uid-001',
+    'Perfecto, voy a proceder con la reserva.',
+    false,
+    NULL,
+    'safetrust'
+  );
+
+-- Conversation 2: active booking with escrow lifecycle messages.
+INSERT INTO public.conversations (
+  id,
+  apartment_id,
+  host_id,
+  guest_id,
+  escrow_id,
+  status,
+  tenant_id
+)
+SELECT
+  '00000000-0000-4000-8000-000000000002'::uuid,
+  '550e8400-e29b-41d4-a716-446655440002'::uuid,
+  'demo-owner-uid-002',
+  'demo-tenant-uid-001',
+  twe.id,
+  'active',
+  'safetrust'
+FROM public.trustless_work_escrows AS twe
+WHERE twe.contract_id = 'CAATN5DTEST00002'
+  AND twe.tenant_id = 'safetrust';
+
+INSERT INTO public.messages (
+  conversation_id,
+  sender_id,
+  body,
+  is_automated,
+  event_type,
+  read_at,
+  tenant_id
+) VALUES
+  (
+    '00000000-0000-4000-8000-000000000002'::uuid,
+    'demo-tenant-uid-001',
+    'SafeTrust: Your escrow contract has been deployed on Stellar. Please fund your deposit to confirm the booking.',
+    true,
+    'booking_confirmed',
+    NOW() - INTERVAL '3 days',
+    'safetrust'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000002'::uuid,
+    'demo-tenant-uid-001',
+    'SafeTrust: Your deposit of $950 USDC has been received and locked in escrow on the Stellar network. Your booking is confirmed.',
+    true,
+    'escrow_funded',
+    NOW() - INTERVAL '2 days',
+    'safetrust'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000002'::uuid,
+    'demo-owner-uid-002',
+    '¡Bienvenido! El apartamento estará listo para el check-in. Te envío las instrucciones de acceso 24h antes.',
+    false,
+    NULL,
+    NULL,
+    'safetrust'
+  ),
+  (
+    '00000000-0000-4000-8000-000000000002'::uuid,
+    'demo-tenant-uid-001',
+    'Gracias! Llegamos mañana alrededor de las 3pm.',
+    false,
+    NULL,
+    NULL,
+    'safetrust'
+  );


### PR DESCRIPTION
## Summary

Adds idempotent seed data for SafeTrust conversations and messages, supporting manual host–guest inquiries and Stellar escrow lifecycle demo scenarios.

- Closes #482

## Changes

- Added `seeds/safetrust/1778100000000_conversations_seed.sql`.
- Added two demo conversation threads:
  - Pre-booking inquiry between a guest and host.
  - Active booking linked to the funded Stellar escrow.
- Added seven realistic messages:
  - Five manual messages.
  - Two automated lifecycle notifications.
- Linked the active booking conversation to `CAATN5DTEST00002`.
- Used deterministic, valid UUIDs for both conversations.
- Added cleanup-before-insert logic for idempotent seed execution.

## Validation

- [x] Seed executed successfully.
- [x] Seed executed successfully a second time without duplicates.
- [x] Exactly 2 conversations were created.
- [x] Exactly 7 messages were created.
- [x] `last_message_at` was populated for both conversations.
- [x] Conversation 2 is linked to the funded Stellar escrow.
- [x] Automated messages have `is_automated = true` and a non-null `event_type`.
- [x] Manual messages have `is_automated = false` and a null `event_type`.
- [x] No trailing-whitespace or diff-check errors.

## Notes

The seed was validated against the schema from the conversations and messages migration dependency. A complete `dc_prep` run requires those prerequisite migrations to be merged into the target branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable SafeTrust demo dataset with pre-booking and active-booking conversations.
  * Included realistic message histories and automated escrow status updates for local development and demonstrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->