### PR TITLE
feat(migration/hotel_industry): add conversations and messages tables (#488)

### DIFF
--- a/migrations/hotel_industry/1778000000002_create_conversations/down.sql
+++ b/migrations/hotel_industry/1778000000002_create_conversations/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.conversations CASCADE;

--- a/migrations/hotel_industry/1778000000002_create_conversations/down.sql
+++ b/migrations/hotel_industry/1778000000002_create_conversations/down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS public.conversations CASCADE;
+DROP TABLE IF EXISTS public.conversations;

--- a/migrations/hotel_industry/1778000000002_create_conversations/up.sql
+++ b/migrations/hotel_industry/1778000000002_create_conversations/up.sql
@@ -36,7 +36,12 @@ CREATE OR REPLACE FUNCTION public.update_hotel_conversation_last_message()
 RETURNS TRIGGER AS $$
 BEGIN
   UPDATE public.conversations
-  SET last_message_at = NEW.created_at, updated_at = NOW()
+  SET last_message_at = CASE
+        WHEN last_message_at IS NULL OR NEW.created_at > last_message_at
+          THEN NEW.created_at
+        ELSE last_message_at
+      END,
+      updated_at = NOW()
   WHERE id = NEW.conversation_id;
   RETURN NEW;
 END;

--- a/migrations/hotel_industry/1778000000002_create_conversations/up.sql
+++ b/migrations/hotel_industry/1778000000002_create_conversations/up.sql
@@ -1,0 +1,43 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS public.conversations (
+  id                    UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  reservation_id        UUID NOT NULL
+                          REFERENCES public.reservations(id) ON DELETE CASCADE,
+  host_id               UUID NOT NULL
+                          REFERENCES public.users(id) ON DELETE CASCADE,
+  guest_id              UUID NOT NULL
+                          REFERENCES public.users(id) ON DELETE CASCADE,
+  escrow_transaction_id UUID
+                          REFERENCES public.escrow_transactions(id) ON DELETE SET NULL,
+  status                VARCHAR(50) NOT NULL DEFAULT 'active'
+                          CHECK (status IN ('active', 'archived', 'blocked')),
+  last_message_at       TIMESTAMP WITH TIME ZONE,
+  created_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at            TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT unique_hotel_conversation UNIQUE (reservation_id, host_id, guest_id),
+  CONSTRAINT hotel_host_guest_different CHECK (host_id != guest_id)
+);
+
+CREATE INDEX idx_hotel_conversations_host
+  ON public.conversations(host_id, last_message_at DESC NULLS LAST);
+
+CREATE INDEX idx_hotel_conversations_guest
+  ON public.conversations(guest_id, last_message_at DESC NULLS LAST);
+
+CREATE INDEX idx_hotel_conversations_reservation
+  ON public.conversations(reservation_id);
+
+CREATE INDEX idx_hotel_conversations_escrow
+  ON public.conversations(escrow_transaction_id)
+  WHERE escrow_transaction_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.update_hotel_conversation_last_message()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE public.conversations
+  SET last_message_at = NEW.created_at, updated_at = NOW()
+  WHERE id = NEW.conversation_id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/hotel_industry/1778000000003_create_messages/down.sql
+++ b/migrations/hotel_industry/1778000000003_create_messages/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS hotel_conversations_update_last_message ON public.messages;
+DROP FUNCTION IF EXISTS public.update_hotel_conversation_last_message();
+DROP TABLE IF EXISTS public.messages CASCADE;

--- a/migrations/hotel_industry/1778000000003_create_messages/down.sql
+++ b/migrations/hotel_industry/1778000000003_create_messages/down.sql
@@ -1,3 +1,3 @@
 DROP TRIGGER IF EXISTS hotel_conversations_update_last_message ON public.messages;
 DROP FUNCTION IF EXISTS public.update_hotel_conversation_last_message();
-DROP TABLE IF EXISTS public.messages CASCADE;
+DROP TABLE IF EXISTS public.messages;

--- a/migrations/hotel_industry/1778000000003_create_messages/up.sql
+++ b/migrations/hotel_industry/1778000000003_create_messages/up.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS public.messages (
+  id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  conversation_id  UUID NOT NULL
+                     REFERENCES public.conversations(id) ON DELETE CASCADE,
+  sender_id        UUID NOT NULL
+                     REFERENCES public.users(id) ON DELETE CASCADE,
+  body             TEXT NOT NULL
+                     CHECK (char_length(body) > 0 AND char_length(body) <= 4000),
+  is_automated     BOOLEAN NOT NULL DEFAULT false,
+  event_type       VARCHAR(100),
+  read_at          TIMESTAMP WITH TIME ZONE,
+  created_at       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  CONSTRAINT hotel_event_type_requires_automated
+    CHECK (event_type IS NULL OR is_automated = true)
+);
+
+CREATE INDEX idx_hotel_messages_conversation
+  ON public.messages(conversation_id, created_at ASC);
+
+CREATE INDEX idx_hotel_messages_unread
+  ON public.messages(conversation_id, sender_id)
+  WHERE read_at IS NULL;
+
+CREATE INDEX idx_hotel_messages_event_type
+  ON public.messages(conversation_id, event_type)
+  WHERE is_automated = true;
+
+CREATE TRIGGER hotel_conversations_update_last_message
+  AFTER INSERT ON public.messages
+  FOR EACH ROW EXECUTE FUNCTION public.update_hotel_conversation_last_message();

--- a/migrations/hotel_industry/1778000000003_create_messages/up.sql
+++ b/migrations/hotel_industry/1778000000003_create_messages/up.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS public.messages (
   is_automated     BOOLEAN NOT NULL DEFAULT false,
   event_type       VARCHAR(100),
   read_at          TIMESTAMP WITH TIME ZONE,
-  created_at       TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_at       TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   CONSTRAINT hotel_event_type_requires_automated
     CHECK (event_type IS NULL OR is_automated = true)
 );


### PR DESCRIPTION
# Pull Request for SafeTrust - Backend

❗ **Pull Request Information**
Adds conversations and messages tables for host-guest messaging linked to reservations under the hotel_industry tenant schema.

## 🌀 Summary of Changes
- **Add conversations migration (`1778000000002_create_conversations`)**: 
  - Created `public.conversations` table referencing `reservations`, `users`, and `escrow_transactions`.
  - Created indexes on `host_id`, `guest_id`, `reservation_id`, and `escrow_transaction_id`.
  - Added `update_hotel_conversation_last_message()` trigger function.
- **Add messages migration (`1778000000003_create_messages`)**: 
  - Created `public.messages` table with length constraints (`1..4000` chars) and `event_type` check constraints.
  - Created indexes for conversation order, unread status, and automated event types.
  - Added `hotel_conversations_update_last_message` trigger `AFTER INSERT` on `messages` (moved to 003 to fix table dependency order).
- **Rollback Safety**:
  - Implemented explicit `down.sql` migrations ensuring clean drops of triggers, functions, and tables in reverse dependency order.

## 🛠 Testing

### Evidence Before Solution
- **Current Behavior**: `hotel_industry` tenant lacked `conversations` and `messages` tables, breaking host-guest chat endpoints.

### Evidence After Solution
- **Fresh Volume Test**: Re-executed `docker compose down -v` and ran `bin/dc_prep hotel_industry` on a pristine database instance.
- **Migration Execution**: Verified clean application with 14/14 migrations showing `Present/Present` in Hasura status.
- **Trigger & Constraint Validation**:
  - Confirmed `hotel_conversations_update_last_message` trigger updates `last_message_at` on message creation.
  - Validated `hotel_host_guest_different` and `hotel_event_type_requires_automated` CHECK constraints.
- **Rollback Test**: Applied `hasura migrate apply --down 2` confirming clean drops of all tables, indexes, and triggers.

```sql
SELECT 'conversations' AS table_name, count(*) FROM conversations
UNION ALL
SELECT 'messages', count(*) FROM messages;

 table_name    | count 
---------------+-------
 conversations |     0
 messages      |     0
```

<img width="1920" height="1080" alt="SafeTrust" src="https://github.com/user-attachments/assets/3bb9870e-ef11-40bc-8065-0e6a64f4b3ce" />

closes #488 

Any feedback or comment is welcome :) thanks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hotel guest-host conversations linked to reservations.
  * Added messaging capabilities with automated messages, event types, read status, and timestamps.
  * Conversation status, participant validation, and message content rules are now enforced.
  * Conversation activity automatically reflects the latest message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->