### PR TITLE
perf: reduce Hasura health check poll interval to 500ms

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -44,18 +44,25 @@ fi
 # ── 2. Wait for Hasura to be healthy ─────────────────────────────────────────
 echo "⏳ Waiting for Hasura to be healthy on ${HASURA_ENDPOINT}..."
 
-max_attempts=90
-attempt=1
-until curl -sf "${HASURA_ENDPOINT}/healthz" > /dev/null; do
-  if [[ "$attempt" -ge "$max_attempts" ]]; then
-    echo "❌ Hasura health check timed out after $((max_attempts * 2)) seconds"
+MAX_WAIT_SECONDS=120
+POLL_INTERVAL=0.5
+START_TS=$SECONDS
+until curl -sf "${HASURA_ENDPOINT}/healthz" > /dev/null 2>&1; do
+  ELAPSED=$((SECONDS - START_TS))
+  if [[ "$ELAPSED" -ge "$MAX_WAIT_SECONDS" ]]; then
+    echo "❌ Hasura health check timed out after ${MAX_WAIT_SECONDS}s"
+    echo "   Last Hasura response:"
+    curl -s "${HASURA_ENDPOINT}/healthz" || true
     exit 1
   fi
-  attempt=$((attempt + 1))
-  sleep 2
+  # Progress indicator every 5 seconds
+  if (( ELAPSED % 5 == 0 && ELAPSED > 0 )); then
+    echo "   ⏳ Still waiting... (${ELAPSED}s elapsed)"
+  fi
+  sleep "$POLL_INTERVAL"
 done
-
-echo "✅ Hasura is healthy"
+HASURA_READY_AT=$((SECONDS - START_TS))
+echo "✅ Hasura is healthy (ready in ${HASURA_READY_AT}s)"
 
 if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
   TIMING_HASURA_HEALTH=$((SECONDS - TIMER_START))


### PR DESCRIPTION
Closes #533 

## Description
This PR addresses a performance bottleneck in `bin/start` where the Hasura health check polled every 2 seconds. The script could previously waste up to 2 full seconds after Hasura became ready before proceeding.

**Changes made:**
- Reduced the poll interval from 2s to 500ms.
- Explicitly defined the timeout in wall-clock seconds (120s) instead of loops/attempts.
- Added a progress indicator that logs every 5 seconds while waiting for Hasura.
- Outputs the time taken for Hasura to become healthy when successful.
- Outputs the last Hasura HTTP response if a timeout occurs for easier debugging.

These changes reduce the average wasted wait time from ~1000ms to ~250ms and makes the health check immediately responsive to Hasura readiness.

## Type of Issue
- Performance

## Acceptance Criteria
- [x] Health poll interval is 500ms
- [x] Timeout is expressed in wall-clock seconds, not attempt count
- [x] Progress logged every 5 seconds during wait
- [x] `HASURA_READY_AT` printed on success: "✅ Hasura is healthy (ready in Xs)"
- [x] On timeout, last Hasura HTTP response is printed for debugging
- [x] All Karate tests pass (`bin/test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup health checks with a two-minute timeout and more frequent status polling.
  - Added periodic progress updates while waiting for service readiness.
  - Enhanced timeout messages with the latest health response for easier troubleshooting.
  - Added readiness timing information when startup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->