### PR TITLE
perf: rust parallel chunk processor for sync-escrows (#548)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,19 @@ HASURA_GRAPHQL_JWT_SECRET='{"type":"HS256","key":"your-32-char-minimum-secret-ke
 # ── TrustlessWork webhook HMAC ────────────────────────────────
 # Shared secret used by the Rust verifier to authenticate escrow callbacks.
 TRUSTLESSWORK_WEBHOOK_SECRET=your-trustlesswork-webhook-secret-here
+
+# ── TrustlessWork indexer (reconciliation sync) ───────────────
+# Base URL + API key used by the reconciliation service to fetch escrow state.
+# Defaults to the public dev indexer when unset.
+TRUSTLESS_WORK_API_URL=https://dev.api.trustlesswork.com
+TRUSTLESS_WORK_API_KEY=
+
+# ── Reconciliation chunk processing ───────────────────────────
+# When true, POST /reconciliation/sync-escrows fetches escrow chunks concurrently
+# via the Rust `chunk-processor` addon (Tokio) instead of the sequential JS loop.
+# Default (unset/false) keeps the sequential path — behaviour is unchanged.
+RUST_CHUNKS_ENABLED=false
+# Max in-flight chunk requests when the Rust path is enabled.
+CHUNK_CONCURRENCY=5
+# Hard per-chunk request timeout, in milliseconds.
+CHUNK_TIMEOUT_MS=5000

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,34 @@
 version = 4
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "base32"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -24,10 +42,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chunk-processor"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "neon 1.1.1",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
 
 [[package]]
 name = "const-oid"
@@ -46,6 +115,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -78,7 +156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -120,6 +198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +245,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,8 +364,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -192,10 +400,229 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -244,10 +671,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "neon"
@@ -324,6 +780,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +799,15 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -343,6 +820,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,13 +885,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -368,6 +991,53 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.28",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "semver"
@@ -403,6 +1073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -439,15 +1110,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -455,14 +1144,30 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "spki"
@@ -475,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stellar-strkey"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,7 +1193,7 @@ checksum = "12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd"
 dependencies = [
  "base32",
  "crate-git-revision",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -546,12 +1257,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -566,6 +1306,148 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,16 +1460,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webhook-verifier"
@@ -599,6 +1589,15 @@ dependencies = [
  "hmac",
  "neon 1.1.1",
  "sha2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -630,10 +1629,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["crates/webhook-verifier", "crates/stellar-utils"]
+members = ["crates/webhook-verifier", "crates/stellar-utils", "crates/chunk-processor"]

--- a/crates/chunk-processor/.gitignore
+++ b/crates/chunk-processor/.gitignore
@@ -1,0 +1,5 @@
+# Compiled Neon addon (platform-specific — always built from source in CI/Docker)
+/index.node
+
+# Cargo build output (root .gitignore also covers target/)
+/target/

--- a/crates/chunk-processor/Cargo.toml
+++ b/crates/chunk-processor/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "chunk-processor"
+version = "0.1.0"
+edition = "2021"
+description = "Neon native addon that fetches escrow chunks from the TrustlessWork indexer concurrently (Tokio + reqwest)"
+
+[lib]
+# cdylib → Node-API addon (index.node); rlib → lets `cargo test` build the pure
+# logic (envelope normalisation, chunk parsing) as a plain test binary without a
+# Node.js runtime — mirrors the stellar-utils / webhook-verifier convention.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+neon       = { version = "1", default-features = false, features = ["napi-6"] }
+# rustls-tls (not native-tls) keeps the build free of a system OpenSSL dependency
+# so it compiles cleanly on the Alpine/musl builder image in webhook/Dockerfile.
+reqwest    = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio      = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
+futures    = "0.3"
+serde      = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros", "test-util"] }

--- a/crates/chunk-processor/README.md
+++ b/crates/chunk-processor/README.md
@@ -15,7 +15,7 @@ async executor — without blocking Node's event loop per request — collapsing
 
 | JS export              | Signature |
 | ---------------------- | --------- |
-| `processChunksParallel` | `(chunksJson: string, apiUrl: string, apiKey: string, maxConcurrency: number, timeoutMs: number) => string` |
+| `processChunksParallel` | `(chunksJson: string, apiUrl: string, apiKey: string, maxConcurrency: number, timeoutMs: number) => Promise<string>` |
 
 `chunksJson` is a JSON-encoded `string[][]` (array of contract-id chunks). The
 return value is a JSON-encoded `ChunkSyncResult[]`, one entry per chunk, ordered

--- a/crates/chunk-processor/README.md
+++ b/crates/chunk-processor/README.md
@@ -8,8 +8,10 @@ It replaces the sequential `for` loop in
 that calls the TrustlessWork indexer one chunk at a time. Each chunk is an
 independent HTTP round-trip, so total sync time is dominated by network latency
 paid **serially**. This addon issues those requests concurrently on Tokio's
-async executor — without blocking Node's event loop per request — collapsing
-`N × latency` into roughly `latency` (bounded by `CHUNK_CONCURRENCY`).
+async executor (without blocking Node's event loop), so the idealized wall-clock
+cost drops from `N × latency` to about `ceil(N / CHUNK_CONCURRENCY) × latency`
+plus overhead. When `CHUNK_CONCURRENCY >= N` that is roughly a single `latency`;
+with more chunks than the limit it scales down by the concurrency factor.
 
 ## What it provides
 

--- a/crates/chunk-processor/README.md
+++ b/crates/chunk-processor/README.md
@@ -1,0 +1,90 @@
+# chunk-processor ⚡
+
+Rust-native, concurrent escrow-chunk fetcher for the SafeTrust reconciliation
+service, exposed to Node.js via **Neon** (Node-API v6).
+
+It replaces the sequential `for` loop in
+[`webhook/src/lib/reconciliation.js`](../../webhook/src/lib/reconciliation.js)
+that calls the TrustlessWork indexer one chunk at a time. Each chunk is an
+independent HTTP round-trip, so total sync time is dominated by network latency
+paid **serially**. This addon issues those requests concurrently on Tokio's
+async executor — without blocking Node's event loop per request — collapsing
+`N × latency` into roughly `latency` (bounded by `CHUNK_CONCURRENCY`).
+
+## What it provides
+
+| JS export              | Signature |
+| ---------------------- | --------- |
+| `processChunksParallel` | `(chunksJson: string, apiUrl: string, apiKey: string, maxConcurrency: number, timeoutMs: number) => string` |
+
+`chunksJson` is a JSON-encoded `string[][]` (array of contract-id chunks). The
+return value is a JSON-encoded `ChunkSyncResult[]`, one entry per chunk, ordered
+by `chunk_index`:
+
+```ts
+interface ChunkSyncResult {
+  chunk_index: number
+  fetched: number       // escrow objects returned for this chunk
+  duration_ms: number   // wall-clock time for this chunk's request
+  error: string | null  // non-null when the chunk failed (isolated)
+  escrows: unknown[]     // raw indexer objects, passed through verbatim
+}
+```
+
+See [`index.d.ts`](./index.d.ts) for the full typed contract.
+
+## Design contract (matches the JavaScript path it replaces)
+
+- **Chunk isolation** — a failed chunk is captured in `error` and never aborts
+  the others. The addon only throws for a caller bug (malformed `chunksJson`).
+- **Lossless pass-through** — escrow objects are returned exactly as the indexer
+  sent them, so the existing UPSERT keeps writing every column (`amount`,
+  `roles.{marker,approver,releaser}`, `escrowType`, …). The DB layer stays in JS.
+- **Response-shape tolerance** — accepts both `{ "escrows": [...] }` and a bare
+  `[...]`, exactly like `fetchEscrowsByContractIds`.
+- **Bounded concurrency** — at most `maxConcurrency` requests are in flight
+  (streaming via `buffer_unordered`, not batch barriers). `0` is clamped to `1`.
+- **Hard per-chunk timeout** — enforced twice: the reqwest per-request timeout
+  and an outer `tokio::time::timeout`, so a chunk always resolves within
+  `timeoutMs`.
+
+## Enabling it
+
+Gated behind an environment flag; default behaviour is unchanged.
+
+```bash
+RUST_CHUNKS_ENABLED=true   # opt in to the parallel path
+CHUNK_CONCURRENCY=5        # max in-flight chunk requests (default 5)
+CHUNK_TIMEOUT_MS=5000      # hard per-chunk timeout (default 5000)
+```
+
+If the addon is missing or fails to load, the service logs a warning and falls
+back to the sequential loop — the endpoint never breaks.
+
+## Build
+
+Prerequisites: Rust toolchain (`cargo`). Targets Node-API v6 (ABI-stable across
+Node versions — no per-Node rebuilds). TLS is via **rustls**, so no system
+OpenSSL is required (clean build on Alpine/musl).
+
+```bash
+# From the repo root — chunk-processor is a workspace member:
+cargo build --release -p chunk-processor
+node crates/chunk-processor/copy-native.js   # → crates/chunk-processor/index.node
+
+# Or as part of the webhook build (builds both addons + TypeScript):
+cd webhook && npm run build
+```
+
+The webhook Docker image builds and ships `index.node` automatically
+(see [`webhook/Dockerfile`](../../webhook/Dockerfile)).
+
+## Test
+
+```bash
+cargo test -p chunk-processor      # pure-logic + concurrency-isolation tests
+node crates/chunk-processor/benchmark.js   # sequential vs parallel timing demo
+```
+
+`benchmark.js` starts a local HTTP server with simulated indexer latency and
+prints the sequential-vs-parallel speedup used in the PR description.

--- a/crates/chunk-processor/benchmark.js
+++ b/crates/chunk-processor/benchmark.js
@@ -1,0 +1,171 @@
+'use strict'
+
+/**
+ * Sequential-vs-parallel benchmark / smoke test for the chunk-processor addon.
+ *
+ * Spins up a mock TrustlessWork indexer with a fixed per-request latency, then
+ * compares:
+ *
+ *   1. Sequential baseline — one HTTP round-trip per chunk, awaited in order
+ *      (what webhook/src/lib/reconciliation.js did before this addon).
+ *   2. Parallel — processChunksParallel() with bounded Tokio concurrency.
+ *
+ * Prints a table of durations and the measured speedup, and asserts the parallel
+ * path returns loss-lessly and isolates a deliberately failing chunk.
+ *
+ * NOTE: processChunksParallel() blocks the Node event loop for its duration
+ * (synchronous bridge), so the mock indexer MUST run in a separate process —
+ * an in-process server could not answer requests while the loop is blocked.
+ * This file forks itself (MODE=server) to host that indexer.
+ *
+ * Run:  node crates/chunk-processor/benchmark.js
+ * (Requires `cargo build --release -p chunk-processor && node copy-native.js`.)
+ */
+
+const http = require('http')
+
+// ── Tunables (env-overridable) ────────────────────────────────────────────────
+const LATENCY_MS = Number(process.env.BENCH_LATENCY_MS || 300) // per-request delay
+const CHUNKS = Number(process.env.BENCH_CHUNKS || 10) // number of chunks
+const CHUNK_SIZE = Number(process.env.BENCH_CHUNK_SIZE || 50) // ids per chunk
+const CONCURRENCY = Number(process.env.BENCH_CONCURRENCY || 5)
+const TIMEOUT_MS = Number(process.env.BENCH_TIMEOUT_MS || 5000)
+
+// ── Child mode: run the mock indexer, report its port over IPC ────────────────
+if (process.env.BENCH_MODE === 'server') {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost')
+    const ids = (url.searchParams.get('contractIds') || '').split(',').filter(Boolean)
+    const escrows = ids.map((id) => ({
+      contractId: id,
+      status: 'funded',
+      amount: '100.0000000',
+      balance: '50.0000000',
+      escrowType: 'single_release',
+      roles: { marker: 'M', approver: 'A', releaser: 'R' },
+    }))
+    setTimeout(() => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ escrows }))
+    }, LATENCY_MS)
+  })
+  server.listen(0, '127.0.0.1', () => {
+    process.send({ port: server.address().port })
+  })
+  return
+}
+
+// ── Parent mode: orchestrate the benchmark ────────────────────────────────────
+const assert = require('assert')
+const { fork } = require('child_process')
+const { processChunksParallel } = require('./index.node')
+
+function buildChunks() {
+  const chunks = []
+  for (let c = 0; c < CHUNKS; c++) {
+    const ids = []
+    for (let i = 0; i < CHUNK_SIZE; i++) ids.push(`C_${c}_${i}`)
+    chunks.push(ids)
+  }
+  return chunks
+}
+
+function startMockIndexer() {
+  return new Promise((resolve) => {
+    const child = fork(__filename, { env: { ...process.env, BENCH_MODE: 'server' } })
+    child.once('message', ({ port }) => {
+      resolve({ child, baseUrl: `http://127.0.0.1:${port}` })
+    })
+  })
+}
+
+function fetchChunkSequential(baseUrl, chunk) {
+  return new Promise((resolve, reject) => {
+    const qs = encodeURIComponent(chunk.join(','))
+    const url = `${baseUrl}/helper/get-escrows-by-contract-ids?contractIds=${qs}`
+    http
+      .get(url, (res) => {
+        let raw = ''
+        res.on('data', (d) => (raw += d))
+        res.on('end', () => resolve(JSON.parse(raw).escrows))
+      })
+      .on('error', reject)
+  })
+}
+
+async function runSequential(baseUrl, chunks) {
+  const start = Date.now()
+  let fetched = 0
+  for (const chunk of chunks) {
+    const escrows = await fetchChunkSequential(baseUrl, chunk)
+    fetched += escrows.length
+  }
+  return { durationMs: Date.now() - start, fetched }
+}
+
+function runParallel(baseUrl, chunks) {
+  const start = Date.now()
+  const json = processChunksParallel(
+    JSON.stringify(chunks),
+    baseUrl,
+    '', // no api key for the mock
+    CONCURRENCY,
+    TIMEOUT_MS
+  )
+  const results = JSON.parse(json)
+  const fetched = results.reduce((n, r) => n + r.fetched, 0)
+  return { durationMs: Date.now() - start, fetched, results }
+}
+
+async function main() {
+  const { child, baseUrl } = await startMockIndexer()
+  try {
+    const chunks = buildChunks()
+    const totalIds = CHUNKS * CHUNK_SIZE
+
+    console.log('chunk-processor benchmark')
+    console.log('─'.repeat(52))
+    console.log(`chunks=${CHUNKS}  chunkSize=${CHUNK_SIZE}  ids=${totalIds}`)
+    console.log(`latency=${LATENCY_MS}ms  concurrency=${CONCURRENCY}\n`)
+
+    const seq = await runSequential(baseUrl, chunks)
+    const par = runParallel(baseUrl, chunks)
+
+    // Correctness: both paths fetch every id, lossless pass-through.
+    assert.strictEqual(seq.fetched, totalIds, 'sequential fetched all ids')
+    assert.strictEqual(par.fetched, totalIds, 'parallel fetched all ids')
+    assert.strictEqual(par.results.length, CHUNKS, 'one result per chunk')
+    assert.deepStrictEqual(
+      par.results[0].escrows[0],
+      {
+        contractId: 'C_0_0',
+        status: 'funded',
+        amount: '100.0000000',
+        balance: '50.0000000',
+        escrowType: 'single_release',
+        roles: { marker: 'M', approver: 'A', releaser: 'R' },
+      },
+      'escrow object passed through verbatim'
+    )
+
+    // Isolation: an unreachable base URL must yield per-chunk errors, no throw.
+    const failed = JSON.parse(
+      processChunksParallel(JSON.stringify(chunks), 'http://127.0.0.1:1', '', CONCURRENCY, 500)
+    )
+    assert.strictEqual(failed.length, CHUNKS)
+    assert.ok(failed.every((r) => r.error), 'every chunk records its own error')
+
+    const speedup = (seq.durationMs / par.durationMs).toFixed(2)
+    console.log(`  sequential : ${seq.durationMs} ms`)
+    console.log(`  parallel   : ${par.durationMs} ms`)
+    console.log(`  speedup    : ${speedup}x\n`)
+    console.log('✅ correctness + isolation assertions passed')
+  } finally {
+    child.kill()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/crates/chunk-processor/benchmark.js
+++ b/crates/chunk-processor/benchmark.js
@@ -13,10 +13,10 @@
  * Prints a table of durations and the measured speedup, and asserts the parallel
  * path returns loss-lessly and isolates a deliberately failing chunk.
  *
- * NOTE: processChunksParallel() blocks the Node event loop for its duration
- * (synchronous bridge), so the mock indexer MUST run in a separate process —
- * an in-process server could not answer requests while the loop is blocked.
- * This file forks itself (MODE=server) to host that indexer.
+ * The mock indexer runs in a forked child process. processChunksParallel() no
+ * longer blocks the event loop (it returns a Promise), so an in-process server
+ * would also work; the child is kept purely to isolate the mock's own latency
+ * timers from the measured loop.
  *
  * Run:  node crates/chunk-processor/benchmark.js
  * (Requires `cargo build --release -p chunk-processor && node copy-native.js`.)
@@ -103,9 +103,9 @@ async function runSequential(baseUrl, chunks) {
   return { durationMs: Date.now() - start, fetched }
 }
 
-function runParallel(baseUrl, chunks) {
+async function runParallel(baseUrl, chunks) {
   const start = Date.now()
-  const json = processChunksParallel(
+  const json = await processChunksParallel(
     JSON.stringify(chunks),
     baseUrl,
     '', // no api key for the mock
@@ -129,7 +129,7 @@ async function main() {
     console.log(`latency=${LATENCY_MS}ms  concurrency=${CONCURRENCY}\n`)
 
     const seq = await runSequential(baseUrl, chunks)
-    const par = runParallel(baseUrl, chunks)
+    const par = await runParallel(baseUrl, chunks)
 
     // Correctness: both paths fetch every id, lossless pass-through.
     assert.strictEqual(seq.fetched, totalIds, 'sequential fetched all ids')
@@ -150,7 +150,7 @@ async function main() {
 
     // Isolation: an unreachable base URL must yield per-chunk errors, no throw.
     const failed = JSON.parse(
-      processChunksParallel(JSON.stringify(chunks), 'http://127.0.0.1:1', '', CONCURRENCY, 500)
+      await processChunksParallel(JSON.stringify(chunks), 'http://127.0.0.1:1', '', CONCURRENCY, 500)
     )
     assert.strictEqual(failed.length, CHUNKS)
     assert.ok(failed.every((r) => r.error), 'every chunk records its own error')

--- a/crates/chunk-processor/copy-native.js
+++ b/crates/chunk-processor/copy-native.js
@@ -1,0 +1,68 @@
+'use strict'
+
+// Copies the compiled cdylib (built by `cargo build --release`) to
+// `index.node` so `require('chunk-processor')` resolves it. Mirrors
+// crates/webhook-verifier/copy-native.js — the workspace target directory is
+// shared, so the artifact may live under the repo-root target/ rather than a
+// crate-local one.
+
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
+
+const crateDir = __dirname
+const dest = path.join(crateDir, 'index.node')
+const libNames = [
+  'libchunk_processor.so',
+  'libchunk_processor.dylib',
+  'chunk_processor.dll',
+]
+
+function cargoTargetDirectory() {
+  try {
+    const meta = JSON.parse(
+      execSync('cargo metadata --format-version 1 --no-deps', {
+        cwd: crateDir,
+        encoding: 'utf8',
+      })
+    )
+    if (meta && typeof meta.target_directory === 'string') {
+      return meta.target_directory
+    }
+  } catch {
+    // Fall through to conventional locations.
+  }
+  return null
+}
+
+const releaseDirs = [
+  path.join(crateDir, 'target', 'release'),
+  path.join(crateDir, '..', '..', 'target', 'release'),
+]
+
+const targetDir = cargoTargetDirectory()
+if (targetDir) {
+  releaseDirs.unshift(path.join(targetDir, 'release'))
+}
+
+let found = null
+for (const dir of releaseDirs) {
+  for (const name of libNames) {
+    const candidate = path.join(dir, name)
+    if (fs.existsSync(candidate)) {
+      found = candidate
+      break
+    }
+  }
+  if (found) break
+}
+
+if (!found) {
+  console.error(
+    'chunk-processor: native library not found. Run `cargo build --release` first.'
+  )
+  process.exit(1)
+}
+
+fs.copyFileSync(found, dest)
+console.log(`chunk-processor: wrote ${dest} from ${found}`)

--- a/crates/chunk-processor/index.d.ts
+++ b/crates/chunk-processor/index.d.ts
@@ -19,15 +19,18 @@ export interface ChunkSyncResult {
  * Fetch every chunk of contract IDs from the TrustlessWork indexer concurrently,
  * with bounded parallelism and a hard per-chunk timeout.
  *
+ * Returns a Promise and does not block the Node.js event loop: the fetches run
+ * on the addon's Tokio runtime and the promise settles when they finish.
+ *
  * Chunk isolation: one failed chunk never aborts the others — its failure is
- * captured in `error`. Only a malformed `chunksJson` argument throws.
+ * captured in `error`. The promise rejects only for a malformed `chunksJson`.
  *
  * @param chunksJson      JSON-encoded `string[][]` — array of contract-id chunks.
  * @param apiUrl          TrustlessWork base URL.
  * @param apiKey          `x-api-key` value; the header is omitted when empty.
  * @param maxConcurrency  Maximum in-flight chunk requests (clamped to >= 1).
  * @param timeoutMs       Hard per-chunk deadline in milliseconds.
- * @returns JSON-encoded `ChunkSyncResult[]`.
+ * @returns Promise resolving to a JSON-encoded `ChunkSyncResult[]`.
  */
 export function processChunksParallel(
   chunksJson: string,
@@ -35,4 +38,4 @@ export function processChunksParallel(
   apiKey: string,
   maxConcurrency: number,
   timeoutMs: number
-): string
+): Promise<string>

--- a/crates/chunk-processor/index.d.ts
+++ b/crates/chunk-processor/index.d.ts
@@ -1,0 +1,38 @@
+/**
+ * One entry per chunk returned by {@link processChunksParallel}. Ordered by
+ * `chunkIndex`. Escrow objects in `escrows` are the indexer's response verbatim,
+ * so the existing UPSERT keeps writing every field it did before.
+ */
+export interface ChunkSyncResult {
+  chunk_index: number
+  /** Number of escrow objects returned for this chunk. */
+  fetched: number
+  /** Wall-clock time this chunk's request took, in milliseconds. */
+  duration_ms: number
+  /** Non-null when the chunk failed (HTTP error, timeout, bad shape). */
+  error: string | null
+  /** Raw escrow objects from the TrustlessWork indexer (empty on error). */
+  escrows: unknown[]
+}
+
+/**
+ * Fetch every chunk of contract IDs from the TrustlessWork indexer concurrently,
+ * with bounded parallelism and a hard per-chunk timeout.
+ *
+ * Chunk isolation: one failed chunk never aborts the others — its failure is
+ * captured in `error`. Only a malformed `chunksJson` argument throws.
+ *
+ * @param chunksJson      JSON-encoded `string[][]` — array of contract-id chunks.
+ * @param apiUrl          TrustlessWork base URL.
+ * @param apiKey          `x-api-key` value; the header is omitted when empty.
+ * @param maxConcurrency  Maximum in-flight chunk requests (clamped to >= 1).
+ * @param timeoutMs       Hard per-chunk deadline in milliseconds.
+ * @returns JSON-encoded `ChunkSyncResult[]`.
+ */
+export function processChunksParallel(
+  chunksJson: string,
+  apiUrl: string,
+  apiKey: string,
+  maxConcurrency: number,
+  timeoutMs: number
+): string

--- a/crates/chunk-processor/package.json
+++ b/crates/chunk-processor/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "chunk-processor",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.node",
+  "types": "index.d.ts",
+  "files": [
+    "index.node",
+    "index.d.ts"
+  ]
+}

--- a/crates/chunk-processor/src/lib.rs
+++ b/crates/chunk-processor/src/lib.rs
@@ -1,0 +1,383 @@
+//! chunk-processor — concurrent escrow-chunk fetcher for SafeTrust reconciliation.
+//!
+//! Replaces the sequential `for` loop in `webhook/src/lib/reconciliation.js` that
+//! calls the TrustlessWork indexer one chunk at a time. Each chunk is an
+//! independent HTTP round-trip, so the work is network-bound and embarrassingly
+//! parallel — a perfect fit for Tokio's async executor, which drives many
+//! in-flight requests on a small thread pool without blocking Node's event loop
+//! per request.
+//!
+//! # Exposed function (via Neon / Node-API v6)
+//!
+//! ```text
+//! processChunksParallel(
+//!   chunksJson:     string,   // JSON: string[][] — array of contract-id chunks
+//!   apiUrl:         string,   // TrustlessWork base URL
+//!   apiKey:         string,   // x-api-key header (omitted when empty)
+//!   maxConcurrency: number,   // max in-flight chunk requests
+//!   timeoutMs:      number,   // hard per-chunk deadline
+//! ) => string                 // JSON: ChunkSyncResult[] — one entry per chunk
+//! ```
+//!
+//! # Design contract (mirrors the JavaScript path it replaces)
+//!
+//! * **Chunk isolation** — one failed chunk never aborts the others. Failures are
+//!   captured in `ChunkSyncResult.error`; the crate itself never throws for a
+//!   network/parse failure (it only throws for a caller bug, e.g. malformed
+//!   `chunksJson`, matching the previous JS behaviour of surfacing bad input).
+//! * **Lossless pass-through** — escrow objects are returned to JS *verbatim* as
+//!   parsed JSON (`serde_json::Value`), so the existing UPSERT keeps writing
+//!   every field it did before (`amount`, `roles.{marker,approver,releaser}`,
+//!   `escrowType`, …). The DB layer is intentionally left in JavaScript.
+//! * **Response-shape tolerance** — the indexer may return `{ "escrows": [...] }`
+//!   or a bare `[...]`; both are accepted, exactly like `fetchEscrowsByContractIds`.
+
+use futures::stream::{self, StreamExt};
+use neon::prelude::*;
+use reqwest::Client;
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::runtime::Runtime;
+
+/// Path segment appended to the TrustlessWork base URL. Kept in sync with
+/// `fetchEscrowsByContractIds` in `webhook/src/lib/reconciliation.js`.
+const INDEXER_PATH: &str = "/helper/get-escrows-by-contract-ids";
+
+/// Result of processing a single chunk. Serialised into the JSON array returned
+/// to JavaScript. `escrows` carries the raw indexer objects so the JS UPSERT is
+/// byte-for-byte unchanged.
+#[derive(Serialize, Debug)]
+struct ChunkSyncResult {
+    chunk_index: usize,
+    fetched: usize,
+    duration_ms: u64,
+    error: Option<String>,
+    escrows: Vec<Value>,
+}
+
+// ─── Shared, lazily-initialised runtime & HTTP client ─────────────────────────
+// One multi-thread Tokio runtime and one connection-pooling reqwest client are
+// reused across every call. Rebuilding them per invocation (as a naive port
+// would) throws away the connection pool and re-spins the thread pool on every
+// sync — measurable overhead on the hot path this crate exists to speed up.
+
+fn runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        Runtime::new().expect("failed to initialise Tokio runtime for chunk-processor")
+    })
+}
+
+fn http_client() -> &'static Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        Client::builder()
+            .build()
+            .expect("failed to build reqwest client for chunk-processor")
+    })
+}
+
+// ─── Pure logic (unit-tested without a Node.js runtime or network) ────────────
+
+/// Parse the `chunksJson` argument into `Vec<Vec<String>>`.
+fn parse_chunks(chunks_json: &str) -> Result<Vec<Vec<String>>, String> {
+    serde_json::from_str(chunks_json)
+        .map_err(|e| format!("invalid chunks JSON: {e}"))
+}
+
+/// Normalise the indexer response body into a flat list of escrow objects.
+///
+/// Accepts either `{ "escrows": [...] }` or a bare `[...]` — the two shapes the
+/// TrustlessWork indexer is known to return — and rejects anything else with the
+/// same wording the JS layer used, so log greps keep working.
+fn normalize_escrows(body: Value) -> Result<Vec<Value>, String> {
+    match body {
+        Value::Array(items) => Ok(items),
+        Value::Object(mut map) => match map.remove("escrows") {
+            Some(Value::Array(items)) => Ok(items),
+            _ => Err(unexpected_shape(&Value::Object(map))),
+        },
+        other => Err(unexpected_shape(&other)),
+    }
+}
+
+fn unexpected_shape(body: &Value) -> String {
+    let mut preview = body.to_string();
+    preview.truncate(200);
+    format!("Unexpected TrustlessWork API response shape: {preview}")
+}
+
+/// Build the indexer URL for a base URL, tolerating a trailing slash.
+fn build_url(api_url: &str) -> String {
+    format!("{}{}", api_url.trim_end_matches('/'), INDEXER_PATH)
+}
+
+// ─── Async fetch + concurrency ────────────────────────────────────────────────
+
+/// Fetch a single chunk from the indexer. Never panics — every failure mode maps
+/// to a descriptive `Err(String)` that becomes `ChunkSyncResult.error`.
+async fn fetch_chunk(
+    client: &Client,
+    api_url: &str,
+    api_key: &str,
+    chunk: &[String],
+    timeout: Duration,
+) -> Result<Vec<Value>, String> {
+    let url = build_url(api_url);
+
+    let mut request = client
+        .get(&url)
+        .timeout(timeout) // reqwest per-request timeout (whole request incl. body)
+        .query(&[("contractIds", chunk.join(","))]);
+
+    // Match the JS helper: only send x-api-key when a key is configured.
+    if !api_key.is_empty() {
+        request = request.header("x-api-key", api_key);
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("HTTP error: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        // Include a short body snippet for diagnosability, like the JS path.
+        let body = response.text().await.unwrap_or_default();
+        let mut snippet = body;
+        snippet.truncate(200);
+        return Err(format!(
+            "TrustlessWork API responded with status {status}: {snippet}"
+        ));
+    }
+
+    let body: Value = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse TrustlessWork API response: {e}"))?;
+
+    normalize_escrows(body)
+}
+
+/// Process every chunk with at most `max_concurrency` requests in flight.
+///
+/// Uses `buffer_unordered` for true streaming bounded concurrency (a new request
+/// starts the instant a slot frees up) rather than fixed batch barriers, which
+/// would stall an entire batch on its slowest chunk. Each future carries its
+/// `chunk_index`, and the collected results are re-sorted by it so the output
+/// order is deterministic regardless of completion order.
+async fn process_chunks(
+    chunks: Vec<Vec<String>>,
+    api_url: String,
+    api_key: String,
+    max_concurrency: usize,
+    timeout_ms: u64,
+) -> Vec<ChunkSyncResult> {
+    let client = http_client();
+    let timeout = Duration::from_millis(timeout_ms);
+    // `buffer_unordered(0)` would mean "unbounded"; a misconfigured 0 must not
+    // silently unleash unlimited concurrency at the indexer.
+    let concurrency = max_concurrency.max(1);
+
+    let mut results: Vec<ChunkSyncResult> = stream::iter(chunks.into_iter().enumerate())
+        .map(|(chunk_index, chunk)| {
+            let api_url = api_url.clone();
+            let api_key = api_key.clone();
+            async move {
+                let started = Instant::now();
+
+                // Hard per-chunk deadline: even if the reqwest timeout is evaded
+                // (e.g. a slow TLS handshake), tokio::time::timeout guarantees the
+                // chunk resolves within timeout_ms.
+                let outcome =
+                    tokio::time::timeout(timeout, fetch_chunk(client, &api_url, &api_key, &chunk, timeout))
+                        .await
+                        .unwrap_or_else(|_| {
+                            Err(format!("chunk timed out after {timeout_ms}ms"))
+                        });
+
+                let duration_ms = started.elapsed().as_millis() as u64;
+                match outcome {
+                    Ok(escrows) => ChunkSyncResult {
+                        chunk_index,
+                        fetched: escrows.len(),
+                        duration_ms,
+                        error: None,
+                        escrows,
+                    },
+                    Err(error) => ChunkSyncResult {
+                        chunk_index,
+                        fetched: 0,
+                        duration_ms,
+                        error: Some(error),
+                        escrows: Vec::new(),
+                    },
+                }
+            }
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
+
+    results.sort_by_key(|r| r.chunk_index);
+    results
+}
+
+// ─── Neon export ──────────────────────────────────────────────────────────────
+
+/// `processChunksParallel(chunksJson, apiUrl, apiKey, maxConcurrency, timeoutMs)`.
+///
+/// Blocks the calling (JS) thread until all chunks resolve — the endpoint is a
+/// background Hasura cron trigger, and the JS integration awaits a synchronous
+/// return, so a blocking bridge keeps the contract simple. Only a caller bug
+/// (malformed `chunksJson`) throws; all network/parse failures are captured
+/// per-chunk in the returned JSON.
+fn process_chunks_parallel(mut cx: FunctionContext) -> JsResult<JsString> {
+    let chunks_json = cx.argument::<JsString>(0)?.value(&mut cx);
+    let api_url = cx.argument::<JsString>(1)?.value(&mut cx);
+    let api_key = cx.argument::<JsString>(2)?.value(&mut cx);
+    let max_concurrency = cx.argument::<JsNumber>(3)?.value(&mut cx) as usize;
+    let timeout_ms = cx.argument::<JsNumber>(4)?.value(&mut cx) as u64;
+
+    let chunks = match parse_chunks(&chunks_json) {
+        Ok(chunks) => chunks,
+        Err(e) => return cx.throw_error(e),
+    };
+
+    let results = runtime().block_on(process_chunks(
+        chunks,
+        api_url,
+        api_key,
+        max_concurrency,
+        timeout_ms,
+    ));
+
+    let json = match serde_json::to_string(&results) {
+        Ok(json) => json,
+        Err(e) => return cx.throw_error(format!("failed to serialise results: {e}")),
+    };
+
+    Ok(cx.string(json))
+}
+
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    cx.export_function("processChunksParallel", process_chunks_parallel)?;
+    Ok(())
+}
+
+// ─── Unit tests (`cargo test`) ────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_nested_chunk_arrays() {
+        let chunks = parse_chunks(r#"[["a","b"],["c"]]"#).unwrap();
+        assert_eq!(chunks, vec![vec!["a", "b"], vec!["c"]]);
+    }
+
+    #[test]
+    fn parses_empty_chunk_list() {
+        assert_eq!(parse_chunks("[]").unwrap(), Vec::<Vec<String>>::new());
+    }
+
+    #[test]
+    fn rejects_malformed_chunk_json() {
+        assert!(parse_chunks("{not json").is_err());
+        // A flat array of strings is not the expected string[][] shape.
+        assert!(parse_chunks(r#"["a","b"]"#).is_err());
+    }
+
+    #[test]
+    fn normalizes_enveloped_response() {
+        let body = json!({ "escrows": [{ "contractId": "C1" }, { "contractId": "C2" }] });
+        let escrows = normalize_escrows(body).unwrap();
+        assert_eq!(escrows.len(), 2);
+        assert_eq!(escrows[0]["contractId"], "C1");
+    }
+
+    #[test]
+    fn normalizes_bare_array_response() {
+        let body = json!([{ "contractId": "C1" }]);
+        let escrows = normalize_escrows(body).unwrap();
+        assert_eq!(escrows.len(), 1);
+    }
+
+    #[test]
+    fn passes_escrow_objects_through_losslessly() {
+        // Fields the JS UPSERT depends on must survive verbatim, including the
+        // string-encoded `amount` the indexer emits.
+        let body = json!({ "escrows": [{
+            "contractId": "C1",
+            "status": "funded",
+            "amount": "100.0000000",
+            "balance": "50.0000000",
+            "escrowType": "single_release",
+            "roles": { "marker": "M", "approver": "A", "releaser": "R" }
+        }]});
+        let escrows = normalize_escrows(body).unwrap();
+        let e = &escrows[0];
+        assert_eq!(e["amount"], "100.0000000");
+        assert_eq!(e["roles"]["approver"], "A");
+        assert_eq!(e["escrowType"], "single_release");
+    }
+
+    #[test]
+    fn rejects_unexpected_shapes() {
+        assert!(normalize_escrows(json!({ "unexpected": true })).is_err());
+        assert!(normalize_escrows(json!({ "escrows": "not-an-array" })).is_err());
+        assert!(normalize_escrows(json!(42)).is_err());
+        // Error wording matches the JS log line so alerts/greps keep working.
+        let err = normalize_escrows(json!({ "unexpected": true })).unwrap_err();
+        assert!(err.starts_with("Unexpected TrustlessWork API response shape:"));
+    }
+
+    #[test]
+    fn builds_indexer_url_tolerating_trailing_slash() {
+        assert_eq!(
+            build_url("https://api.example.com"),
+            "https://api.example.com/helper/get-escrows-by-contract-ids"
+        );
+        assert_eq!(
+            build_url("https://api.example.com/"),
+            "https://api.example.com/helper/get-escrows-by-contract-ids"
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_chunks_are_isolated_and_indexed() {
+        // Unroutable address → every chunk fails fast, but the call still returns
+        // one result per chunk, each carrying its own error and correct index.
+        let chunks = vec![vec!["a".to_string()], vec!["b".to_string()], vec!["c".to_string()]];
+        let results = process_chunks(
+            chunks,
+            "http://127.0.0.1:0".to_string(), // port 0 is not connectable
+            String::new(),
+            2,
+            200,
+        )
+        .await;
+
+        assert_eq!(results.len(), 3);
+        for (i, r) in results.iter().enumerate() {
+            assert_eq!(r.chunk_index, i, "results must be ordered by chunk_index");
+            assert!(r.error.is_some(), "unreachable host must yield a per-chunk error");
+            assert_eq!(r.fetched, 0);
+            assert!(r.escrows.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn zero_concurrency_is_clamped_not_unbounded() {
+        // max_concurrency = 0 must be treated as 1, never as "unbounded".
+        let chunks = vec![vec!["a".to_string()]];
+        let results =
+            process_chunks(chunks, "http://127.0.0.1:0".to_string(), String::new(), 0, 100).await;
+        assert_eq!(results.len(), 1);
+    }
+}

--- a/crates/chunk-processor/src/lib.rs
+++ b/crates/chunk-processor/src/lib.rs
@@ -103,9 +103,22 @@ fn normalize_escrows(body: Value) -> Result<Vec<Value>, String> {
     }
 }
 
+/// Truncate `s` to at most `max` bytes, snapping back to the nearest UTF-8 char
+/// boundary so indexer-controlled (possibly non-ASCII) text never panics.
+fn truncate_on_boundary(s: &mut String, max: usize) {
+    if s.len() <= max {
+        return;
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+}
+
 fn unexpected_shape(body: &Value) -> String {
     let mut preview = body.to_string();
-    preview.truncate(200);
+    truncate_on_boundary(&mut preview, 200);
     format!("Unexpected TrustlessWork API response shape: {preview}")
 }
 
@@ -145,9 +158,8 @@ async fn fetch_chunk(
     let status = response.status();
     if !status.is_success() {
         // Include a short body snippet for diagnosability, like the JS path.
-        let body = response.text().await.unwrap_or_default();
-        let mut snippet = body;
-        snippet.truncate(200);
+        let mut snippet = response.text().await.unwrap_or_default();
+        truncate_on_boundary(&mut snippet, 200);
         return Err(format!(
             "TrustlessWork API responded with status {status}: {snippet}"
         ));
@@ -336,6 +348,29 @@ mod tests {
         assert_eq!(e["amount"], "100.0000000");
         assert_eq!(e["roles"]["approver"], "A");
         assert_eq!(e["escrowType"], "single_release");
+    }
+
+    #[test]
+    fn truncate_on_boundary_never_splits_a_multibyte_char() {
+        // 'é' is two bytes, so every odd byte index is mid-character. A naive
+        // String::truncate at such an index would panic.
+        let mut s = "é".repeat(200); // 400 bytes
+        truncate_on_boundary(&mut s, 201);
+        assert!(s.len() <= 201);
+        assert!(s.is_char_boundary(s.len()), "must end on a char boundary");
+
+        // Non-ASCII shorter than max is left untouched.
+        let mut short = "café".to_string();
+        truncate_on_boundary(&mut short, 200);
+        assert_eq!(short, "café");
+    }
+
+    #[test]
+    fn unexpected_shape_survives_non_ascii_body() {
+        // A valid non-ASCII response must yield an error string, never a panic.
+        let long = "☕".repeat(300);
+        let err = unexpected_shape(&serde_json::Value::String(long));
+        assert!(err.starts_with("Unexpected TrustlessWork API response shape:"));
     }
 
     #[test]

--- a/crates/chunk-processor/src/lib.rs
+++ b/crates/chunk-processor/src/lib.rs
@@ -16,7 +16,7 @@
 //!   apiKey:         string,   // x-api-key header (omitted when empty)
 //!   maxConcurrency: number,   // max in-flight chunk requests
 //!   timeoutMs:      number,   // hard per-chunk deadline
-//! ) => string                 // JSON: ChunkSyncResult[] — one entry per chunk
+//! ) => Promise<string>        // JSON: ChunkSyncResult[] — one entry per chunk
 //! ```
 //!
 //! # Design contract (mirrors the JavaScript path it replaces)
@@ -229,37 +229,48 @@ async fn process_chunks(
 
 /// `processChunksParallel(chunksJson, apiUrl, apiKey, maxConcurrency, timeoutMs)`.
 ///
-/// Blocks the calling (JS) thread until all chunks resolve — the endpoint is a
-/// background Hasura cron trigger, and the JS integration awaits a synchronous
-/// return, so a blocking bridge keeps the contract simple. Only a caller bug
-/// (malformed `chunksJson`) throws; all network/parse failures are captured
-/// per-chunk in the returned JSON.
-fn process_chunks_parallel(mut cx: FunctionContext) -> JsResult<JsString> {
+/// Returns a `Promise<string>` and does NOT block the Node.js event loop. The
+/// chunk fetches run on the shared Tokio runtime's own threads; when they finish
+/// the promise is settled back on the JS thread via a Neon `Channel`. So while a
+/// sync is in flight the event loop stays free to serve other requests, and the
+/// wall-clock time (which can exceed a single `timeoutMs` when chunks run in
+/// waves) never stalls unrelated work.
+///
+/// The returned promise rejects only for a caller bug (malformed `chunksJson`);
+/// all network/parse failures are captured per-chunk in the resolved JSON.
+fn process_chunks_parallel(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let chunks_json = cx.argument::<JsString>(0)?.value(&mut cx);
     let api_url = cx.argument::<JsString>(1)?.value(&mut cx);
     let api_key = cx.argument::<JsString>(2)?.value(&mut cx);
     let max_concurrency = cx.argument::<JsNumber>(3)?.value(&mut cx) as usize;
     let timeout_ms = cx.argument::<JsNumber>(4)?.value(&mut cx) as u64;
 
+    let (deferred, promise) = cx.promise();
+    let channel = cx.channel();
+
+    // Parse up front so a malformed argument rejects the promise immediately,
+    // without spawning any work.
     let chunks = match parse_chunks(&chunks_json) {
         Ok(chunks) => chunks,
-        Err(e) => return cx.throw_error(e),
+        Err(e) => {
+            let error = cx.error(e)?;
+            deferred.reject(&mut cx, error);
+            return Ok(promise);
+        }
     };
 
-    let results = runtime().block_on(process_chunks(
-        chunks,
-        api_url,
-        api_key,
-        max_concurrency,
-        timeout_ms,
-    ));
+    // Run the fetches on the Tokio runtime, then settle the promise on the JS
+    // thread. `settle_with` schedules its closure on the event loop via `channel`.
+    runtime().spawn(async move {
+        let results = process_chunks(chunks, api_url, api_key, max_concurrency, timeout_ms).await;
+        deferred.settle_with(&channel, move |mut cx| {
+            let json = serde_json::to_string(&results)
+                .or_else(|e| cx.throw_error(format!("failed to serialise results: {e}")))?;
+            Ok(cx.string(json))
+        });
+    });
 
-    let json = match serde_json::to_string(&results) {
-        Ok(json) => json,
-        Err(e) => return cx.throw_error(format!("failed to serialise results: {e}")),
-    };
-
-    Ok(cx.string(json))
+    Ok(promise)
 }
 
 #[neon::main]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,10 @@ services:
 
   webhook:
     build:
-      context: ./webhook      # ← fixed: local path within backend repo
-      dockerfile: Dockerfile
+      # Repo root: the webhook image needs the root Cargo workspace (Cargo.toml,
+      # Cargo.lock, crates/) alongside webhook/, so it cannot build from ./webhook.
+      context: .
+      dockerfile: webhook/Dockerfile
       cache_from:
         - type=local,src=/tmp/docker-cache/webhook
       cache_to:

--- a/webhook/Dockerfile
+++ b/webhook/Dockerfile
@@ -1,27 +1,30 @@
 # ── Stage 1: Build ────────────────────────────────────────────────────────────
 FROM node:24-alpine AS builder
 
-# Rust toolchain for both Neon addons (webhook-verifier + stellar-utils).
-# gcc + musl-dev provide the C linker and musl headers rustc needs on Alpine.
+# Rust toolchain for the Neon addons (webhook-verifier, stellar-utils,
+# chunk-processor). gcc + musl-dev provide the C linker and musl headers rustc
+# needs on Alpine.
 RUN apk add --no-cache curl build-base rust cargo gcc musl-dev
 
+# Build context is the repo root, so source paths are repo-root relative.
 WORKDIR /app
 
+# 1. Node dependencies first (cached until package.json changes).
 COPY webhook/package*.json ./webhook/
-WORKDIR /app/webhook
-RUN npm ci
+RUN cd webhook && npm ci
 
-COPY tsconfig.json ./
+# 2. Rust workspace: root manifest + lockfile + all member crates at /app so
+#    `cargo build --workspace --manifest-path ../Cargo.toml` resolves from webhook.
+COPY Cargo.toml Cargo.lock ./
 COPY crates/ ./crates/
 
-# Build the Rust crate → native/index.node (Node-API v6, ABI-stable).
-RUN cd crates/stellar-utils \
-    && cargo build --release \
-    && mkdir -p native \
-    && cp target/release/libstellar_utils.so native/index.node
+# 3. TypeScript sources + config.
+COPY webhook/tsconfig.json ./webhook/
+COPY webhook/src/ ./webhook/src/
 
-COPY src/ ./src/
-RUN npm run build
+# 4. Build the Neon addons (cargo --workspace → each crate's copy-native.js) and
+#    compile TypeScript. See webhook/package.json "build" script.
+RUN cd webhook && npm run build
 
 # ── Stage 2: Production ───────────────────────────────────────────────────────
 FROM node:24-alpine AS production

--- a/webhook/Dockerfile
+++ b/webhook/Dockerfile
@@ -41,6 +41,9 @@ COPY --from=builder /app/crates/webhook-verifier/package.json /app/crates/webhoo
 # dist/routes/auth resolves correctly.
 COPY --from=builder /app/crates/stellar-utils/package.json /app/crates/stellar-utils/package.json
 COPY --from=builder /app/crates/stellar-utils/native /app/crates/stellar-utils/native
+# chunk-processor: parallel escrow-chunk fetcher (built by build:rust --workspace).
+COPY --from=builder /app/crates/chunk-processor/index.node /app/crates/chunk-processor/index.node
+COPY --from=builder /app/crates/chunk-processor/package.json /app/crates/chunk-processor/package.json
 
 # node user/group already exists in official node:24-alpine image
 USER node

--- a/webhook/package.json
+++ b/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build:rust": "cargo build --release --workspace --manifest-path ../Cargo.toml && node ../crates/webhook-verifier/copy-native.js && node ../crates/stellar-utils/copy-native.js",
+    "build:rust": "cargo build --release --workspace --manifest-path ../Cargo.toml && node ../crates/webhook-verifier/copy-native.js && node ../crates/stellar-utils/copy-native.js && node ../crates/chunk-processor/copy-native.js",
     "build": "npm run build:rust && tsc",
     "dev": "nodemon --exec ts-node src/index.ts",
     "start": "node dist/index.js",

--- a/webhook/src/lib/__tests__/reconciliation-parallel.test.js
+++ b/webhook/src/lib/__tests__/reconciliation-parallel.test.js
@@ -128,7 +128,7 @@ describe('syncChunksParallel', () => {
     process.env.CHUNK_CONCURRENCY = '3';
     process.env.CHUNK_TIMEOUT_MS = '1234';
 
-    const processChunksParallel = jest.fn(() =>
+    const processChunksParallel = jest.fn(async () =>
       JSON.stringify([
         { chunk_index: 0, fetched: 1, duration_ms: 10, error: null, escrows: [makeEscrow({ contractId: 'C1' })] },
         { chunk_index: 1, fetched: 1, duration_ms: 12, error: null, escrows: [makeEscrow({ contractId: 'C2' })] },
@@ -150,7 +150,7 @@ describe('syncChunksParallel', () => {
   });
 
   it('records a failed chunk in errors and still upserts the healthy ones', async () => {
-    const processChunksParallel = jest.fn(() =>
+    const processChunksParallel = jest.fn(async () =>
       JSON.stringify([
         { chunk_index: 0, fetched: 0, duration_ms: 5000, error: 'chunk timed out after 5000ms', escrows: [] },
         { chunk_index: 1, fetched: 1, duration_ms: 20, error: null, escrows: [makeEscrow({ contractId: 'C2' })] },
@@ -220,7 +220,7 @@ describe('syncAllChunks', () => {
 
   it('routes through the Rust addon when RUST_CHUNKS_ENABLED=true', async () => {
     process.env.RUST_CHUNKS_ENABLED = 'true';
-    const processChunksParallel = jest.fn(() =>
+    const processChunksParallel = jest.fn(async () =>
       JSON.stringify([
         { chunk_index: 0, fetched: 1, duration_ms: 8, error: null, escrows: [makeEscrow({ contractId: 'C1' })] },
       ])

--- a/webhook/src/lib/__tests__/reconciliation-parallel.test.js
+++ b/webhook/src/lib/__tests__/reconciliation-parallel.test.js
@@ -1,0 +1,248 @@
+'use strict';
+
+/**
+ * @file src/lib/__tests__/reconciliation-parallel.test.js
+ *
+ * Unit tests for the parallel chunk-processing integration added alongside the
+ * Rust `chunk-processor` addon:
+ *   • upsertEscrows        → shared UPSERT loop (counts + per-row isolation)
+ *   • syncAllChunks (seq)  → sequential aggregation + chunk-error isolation
+ *   • syncChunksParallel   → Rust-path glue, with the addon faked via the test seam
+ *   • syncAllChunks (rust) → routes through the addon when RUST_CHUNKS_ENABLED=true,
+ *                            and falls back to sequential when the addon is absent
+ *
+ * The native addon is never loaded here — a fake is injected via the exported
+ * test seam so these tests run with zero Rust build.
+ */
+
+jest.mock('../../services/db', () => ({ query: jest.fn() }));
+
+// Explicit factory (not bare automock): guarantees `https.request` is a mock fn
+// across Node versions — Node's automock of the core `https` module does not
+// reliably replace `request` with a jest.fn.
+jest.mock('https', () => ({ request: jest.fn() }));
+const https = require('https');
+
+const db = require('../../services/db');
+const {
+  upsertEscrows,
+  syncAllChunks,
+  syncChunksParallel,
+  __setChunkProcessorForTests,
+  __resetChunkProcessorForTests,
+} = require('../reconciliation');
+
+function makeEscrow(overrides = {}) {
+  return {
+    contractId: 'C1',
+    status: 'funded',
+    amount: '100.0000000',
+    balance: '50.0000000',
+    escrowType: 'single_release',
+    roles: { marker: 'M', approver: 'A', releaser: 'R' },
+    ...overrides,
+  };
+}
+
+/** Make https.request return a JSON body — used by the sequential path. */
+function mockHttpResponse(body, statusCode = 200) {
+  const { EventEmitter } = require('events');
+  const fakeRes = new EventEmitter();
+  fakeRes.statusCode = statusCode;
+  fakeRes.setEncoding = jest.fn();
+  const fakeReq = new EventEmitter();
+  fakeReq.setTimeout = jest.fn();
+  fakeReq.destroy = jest.fn();
+  fakeReq.end = jest.fn(() => {
+    process.nextTick(() => {
+      fakeRes.emit('data', typeof body === 'string' ? body : JSON.stringify(body));
+      fakeRes.emit('end');
+    });
+  });
+  https.request.mockImplementation((_opts, cb) => {
+    cb(fakeRes);
+    return fakeReq;
+  });
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+  __resetChunkProcessorForTests();
+  delete process.env.RUST_CHUNKS_ENABLED;
+  delete process.env.CHUNK_CONCURRENCY;
+  delete process.env.CHUNK_TIMEOUT_MS;
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// upsertEscrows — the shared UPSERT loop
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('upsertEscrows', () => {
+  it('counts updated vs unchanged from the RETURNING result', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ contract_id: 'C1' }] }) // changed → updated
+      .mockResolvedValueOnce({ rows: [] }); // no change → unchanged
+
+    const result = await upsertEscrows([
+      makeEscrow({ contractId: 'C1' }),
+      makeEscrow({ contractId: 'C2' }),
+    ]);
+    expect(result).toEqual({ updated: 1, unchanged: 1, skipped: 0 });
+  });
+
+  it('writes every indexed column (amount, roles, escrowType) verbatim', async () => {
+    db.query.mockResolvedValue({ rows: [{ contract_id: 'C1' }] });
+    await upsertEscrows([makeEscrow()]);
+
+    const params = db.query.mock.calls[0][1];
+    // $1 contract_id, $2 status, $3 amount, $4 balance, $5 marker, $6 approver,
+    // $7 releaser, $8 escrow_type
+    expect(params).toEqual([
+      'C1', 'funded', '100.0000000', '50.0000000', 'M', 'A', 'R', 'single_release',
+    ]);
+  });
+
+  it('isolates a per-row DB error as skipped', async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ contract_id: 'GOOD' }] })
+      .mockRejectedValueOnce(new Error('constraint violation'));
+
+    const result = await upsertEscrows([
+      makeEscrow({ contractId: 'GOOD' }),
+      makeEscrow({ contractId: 'BAD' }),
+    ]);
+    expect(result).toEqual({ updated: 1, unchanged: 0, skipped: 1 });
+  });
+
+  it('skips escrows missing contractId without touching the DB', async () => {
+    const result = await upsertEscrows([{ status: 'funded' }]);
+    expect(result).toEqual({ updated: 0, unchanged: 0, skipped: 1 });
+    expect(db.query).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// syncChunksParallel — Rust-path glue (addon faked)
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('syncChunksParallel', () => {
+  it('forwards config to the addon and upserts each chunk’s escrows', async () => {
+    process.env.CHUNK_CONCURRENCY = '3';
+    process.env.CHUNK_TIMEOUT_MS = '1234';
+
+    const processChunksParallel = jest.fn(() =>
+      JSON.stringify([
+        { chunk_index: 0, fetched: 1, duration_ms: 10, error: null, escrows: [makeEscrow({ contractId: 'C1' })] },
+        { chunk_index: 1, fetched: 1, duration_ms: 12, error: null, escrows: [makeEscrow({ contractId: 'C2' })] },
+      ])
+    );
+    __setChunkProcessorForTests({ processChunksParallel });
+    db.query.mockResolvedValue({ rows: [{ contract_id: 'x' }] }); // every row updated
+
+    const chunks = [['C1'], ['C2']];
+    const result = await syncChunksParallel(chunks);
+
+    expect(result).toEqual({ updated: 2, unchanged: 0, skipped: 0, errors: [] });
+
+    // Args: chunksJson, apiUrl, apiKey, concurrency, timeoutMs
+    const args = processChunksParallel.mock.calls[0];
+    expect(JSON.parse(args[0])).toEqual(chunks);
+    expect(args[3]).toBe(3);
+    expect(args[4]).toBe(1234);
+  });
+
+  it('records a failed chunk in errors and still upserts the healthy ones', async () => {
+    const processChunksParallel = jest.fn(() =>
+      JSON.stringify([
+        { chunk_index: 0, fetched: 0, duration_ms: 5000, error: 'chunk timed out after 5000ms', escrows: [] },
+        { chunk_index: 1, fetched: 1, duration_ms: 20, error: null, escrows: [makeEscrow({ contractId: 'C2' })] },
+      ])
+    );
+    __setChunkProcessorForTests({ processChunksParallel });
+    db.query.mockResolvedValue({ rows: [{ contract_id: 'C2' }] });
+
+    const result = await syncChunksParallel([['C1'], ['C2']]);
+    expect(result.updated).toBe(1);
+    expect(result.errors).toEqual(['chunk_0: chunk timed out after 5000ms']);
+  });
+
+  it('throws when the addon is unavailable so the caller can fall back', async () => {
+    __setChunkProcessorForTests(null); // no addon
+    await expect(syncChunksParallel([['C1']])).rejects.toThrow(/not loaded/i);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// syncAllChunks — path selection
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('syncAllChunks', () => {
+  it('returns zero counts and 0 chunks for an empty id list', async () => {
+    const result = await syncAllChunks([]);
+    expect(result).toEqual({ chunks: 0, updated: 0, unchanged: 0, skipped: 0, errors: [] });
+  });
+
+  it('uses the sequential path by default (flag unset) and isolates a bad chunk', async () => {
+    // 60 ids → 2 chunks of [50, 10]. First chunk OK, second chunk HTTP-fails.
+    const ids = Array.from({ length: 60 }, (_, i) => `ID_${i}`);
+
+    let call = 0;
+    const { EventEmitter } = require('events');
+    https.request.mockImplementation((_opts, cb) => {
+      const fakeReq = new EventEmitter();
+      fakeReq.setTimeout = jest.fn();
+      fakeReq.destroy = jest.fn();
+      call += 1;
+      if (call === 2) {
+        // Second chunk: emit a request error → syncChunk rejects → isolated.
+        fakeReq.end = jest.fn(() =>
+          process.nextTick(() => fakeReq.emit('error', new Error('ECONNREFUSED')))
+        );
+        return fakeReq;
+      }
+      const fakeRes = new EventEmitter();
+      fakeRes.statusCode = 200;
+      fakeRes.setEncoding = jest.fn();
+      fakeReq.end = jest.fn(() =>
+        process.nextTick(() => {
+          fakeRes.emit('data', JSON.stringify({ escrows: [makeEscrow({ contractId: 'ID_0' })] }));
+          fakeRes.emit('end');
+        })
+      );
+      cb(fakeRes);
+      return fakeReq;
+    });
+    db.query.mockResolvedValue({ rows: [{ contract_id: 'ID_0' }] });
+
+    const result = await syncAllChunks(ids);
+    expect(result.chunks).toBe(2);
+    expect(result.updated).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/^chunk_1:/);
+  });
+
+  it('routes through the Rust addon when RUST_CHUNKS_ENABLED=true', async () => {
+    process.env.RUST_CHUNKS_ENABLED = 'true';
+    const processChunksParallel = jest.fn(() =>
+      JSON.stringify([
+        { chunk_index: 0, fetched: 1, duration_ms: 8, error: null, escrows: [makeEscrow({ contractId: 'C1' })] },
+      ])
+    );
+    __setChunkProcessorForTests({ processChunksParallel });
+    db.query.mockResolvedValue({ rows: [{ contract_id: 'C1' }] });
+
+    const result = await syncAllChunks(['C1']);
+    expect(processChunksParallel).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ chunks: 1, updated: 1, unchanged: 0, skipped: 0, errors: [] });
+    // The sequential path must not have fired.
+    expect(https.request).not.toHaveBeenCalled();
+  });
+
+  it('falls back to sequential when the flag is on but the addon is missing', async () => {
+    process.env.RUST_CHUNKS_ENABLED = 'true';
+    __setChunkProcessorForTests(null); // addon unavailable
+    mockHttpResponse({ escrows: [makeEscrow({ contractId: 'C1' })] });
+    db.query.mockResolvedValue({ rows: [{ contract_id: 'C1' }] });
+
+    const result = await syncAllChunks(['C1']);
+    expect(result).toEqual({ chunks: 1, updated: 1, unchanged: 0, skipped: 0, errors: [] });
+    expect(https.request).toHaveBeenCalledTimes(1); // proves sequential ran
+  });
+});

--- a/webhook/src/lib/__tests__/reconciliation.test.js
+++ b/webhook/src/lib/__tests__/reconciliation.test.js
@@ -20,8 +20,11 @@ jest.mock('../../services/db', () => ({
 }));
 
 // ─── Mock Node's built-in https so no real network calls fire ─────────────────
+// Explicit factory (not bare automock): Node's automock of the core `https`
+// module does not reliably replace `request` with a jest.fn on Node 18+, so
+// `https.request.mockImplementation` would throw. The factory guarantees it.
+jest.mock('https', () => ({ request: jest.fn() }));
 const https = require('https');
-jest.mock('https');
 
 const db = require('../../services/db');
 const {

--- a/webhook/src/lib/reconciliation.js
+++ b/webhook/src/lib/reconciliation.js
@@ -333,7 +333,9 @@ async function syncChunksParallel(chunks) {
   const concurrency = envInt('CHUNK_CONCURRENCY', 5);
   const timeoutMs = envInt('CHUNK_TIMEOUT_MS', 5000);
 
-  const resultsJson = addon.processChunksParallel(
+  // processChunksParallel returns a Promise<string> — awaiting it keeps the
+  // Node event loop free while the Rust runtime does the concurrent fetches.
+  const resultsJson = await addon.processChunksParallel(
     JSON.stringify(chunks),
     TW_BASE_URL,
     TW_API_KEY,

--- a/webhook/src/lib/reconciliation.js
+++ b/webhook/src/lib/reconciliation.js
@@ -27,6 +27,72 @@ const TW_BASE_URL =
   process.env.TRUSTLESS_WORK_API_URL || 'https://dev.api.trustlesswork.com';
 const TW_API_KEY = process.env.TRUSTLESS_WORK_API_KEY || '';
 
+// ─── Optional Rust parallel chunk processor ──────────────────────────────────
+/**
+ * When RUST_CHUNKS_ENABLED=true, chunk HTTP requests are executed concurrently
+ * by the `chunk-processor` Neon addon (Tokio + reqwest) instead of the sequential
+ * JS loop. The DB UPSERT stays in JavaScript — the addon only parallelises the
+ * network-bound fetch and hands escrow objects back verbatim, so counts and the
+ * response JSON are identical to the sequential path.
+ *
+ * Everything below is gated: with the flag unset (default) the addon is never
+ * loaded and behaviour is byte-for-byte unchanged.
+ */
+const CHUNK_PROCESSOR_MODULE = '../../../crates/chunk-processor';
+
+/** Parse an int env var, falling back to `fallback` on absent/invalid values. */
+function envInt(name, fallback) {
+  const parsed = parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/** True when the operator has opted into the Rust parallel path. */
+function isRustChunkProcessingEnabled() {
+  return process.env.RUST_CHUNKS_ENABLED === 'true';
+}
+
+// Lazily require the native addon so the flag-off path never touches it and a
+// missing/unbuilt binary can degrade gracefully to the sequential loop.
+let _chunkProcessor = null;
+let _chunkProcessorLoadFailed = false;
+// Test seam: lets unit tests inject a fake addon (or simulate an unavailable one)
+// without a native build. `undefined` means "no override" — prod code never
+// touches it, so the real require path runs.
+let _chunkProcessorOverride;
+function loadChunkProcessor() {
+  // A set override (object OR null) short-circuits the real require. `null`
+  // deliberately simulates an unavailable addon.
+  if (_chunkProcessorOverride !== undefined) return _chunkProcessorOverride;
+  if (_chunkProcessor || _chunkProcessorLoadFailed) return _chunkProcessor;
+  try {
+    _chunkProcessor = require(CHUNK_PROCESSOR_MODULE);
+  } catch (err) {
+    _chunkProcessorLoadFailed = true;
+    console.error(
+      '[reconciliation] ⚠️  chunk-processor addon unavailable — ' +
+        `falling back to sequential sync: ${err.message}`
+    );
+  }
+  return _chunkProcessor;
+}
+
+/**
+ * @internal Test-only: force `loadChunkProcessor()` to return `mock` (pass `null`
+ * to simulate an unavailable addon).
+ */
+function __setChunkProcessorForTests(mock) {
+  _chunkProcessorOverride = mock;
+  _chunkProcessor = null;
+  _chunkProcessorLoadFailed = false;
+}
+
+/** @internal Test-only: drop the override and restore the real require path. */
+function __resetChunkProcessorForTests() {
+  _chunkProcessorOverride = undefined;
+  _chunkProcessor = null;
+  _chunkProcessorLoadFailed = false;
+}
+
 // ─── Idempotent UPSERT ────────────────────────────────────────────────────────
 /**
  * INSERT … ON CONFLICT (contract_id) DO UPDATE …
@@ -180,18 +246,18 @@ async function fetchEscrowsByContractIds(contractIds) {
 }
 
 /**
- * Upsert a single chunk of contract IDs into public.trustless_work_escrows.
+ * Upsert an array of escrow objects into public.trustless_work_escrows.
  *
  * Escrows whose indexed fields have not changed are skipped (IS DISTINCT FROM).
- * Each escrow in the chunk is processed independently so one bad record does
- * not abort the entire batch.
+ * Each escrow is processed independently so one bad record does not abort the
+ * batch. Shared by the sequential path ({@link syncChunk}) and the Rust parallel
+ * path ({@link syncChunksParallel}) so both write identical columns with
+ * identical counting — the only difference is how the escrows were fetched.
  *
- * @param {string[]} contractIds  Up to CHUNK_SIZE contract IDs.
+ * @param {object[]} escrows  Escrow objects as returned by the indexer.
  * @returns {Promise<{updated: number, unchanged: number, skipped: number}>}
  */
-async function syncChunk(contractIds) {
-  const escrows = await fetchEscrowsByContractIds(contractIds);
-
+async function upsertEscrows(escrows) {
   let updated = 0;
   let unchanged = 0;
   let skipped = 0;
@@ -236,6 +302,128 @@ async function syncChunk(contractIds) {
 }
 
 /**
+ * Fetch one chunk of contract IDs from the indexer and upsert the results.
+ *
+ * Thin composition of {@link fetchEscrowsByContractIds} + {@link upsertEscrows};
+ * a network failure rejects so the caller can isolate this chunk from the rest.
+ *
+ * @param {string[]} contractIds  Up to CHUNK_SIZE contract IDs.
+ * @returns {Promise<{updated: number, unchanged: number, skipped: number}>}
+ */
+async function syncChunk(contractIds) {
+  const escrows = await fetchEscrowsByContractIds(contractIds);
+  return upsertEscrows(escrows);
+}
+
+/**
+ * Fetch every chunk concurrently via the Rust addon, then upsert each chunk's
+ * escrows in JavaScript. Preserves the chunk-isolation contract: a chunk whose
+ * HTTP request failed is recorded in `errors` and never aborts the others.
+ *
+ * @param {string[][]} chunks  Pre-split contract-id chunks.
+ * @returns {Promise<{updated:number, unchanged:number, skipped:number, errors:string[]}>}
+ */
+async function syncChunksParallel(chunks) {
+  const addon = loadChunkProcessor();
+  if (!addon) {
+    // Signal the caller to fall back to the sequential path.
+    throw new Error('chunk-processor addon not loaded');
+  }
+
+  const concurrency = envInt('CHUNK_CONCURRENCY', 5);
+  const timeoutMs = envInt('CHUNK_TIMEOUT_MS', 5000);
+
+  const resultsJson = addon.processChunksParallel(
+    JSON.stringify(chunks),
+    TW_BASE_URL,
+    TW_API_KEY,
+    concurrency,
+    timeoutMs
+  );
+
+  const chunkResults = JSON.parse(resultsJson);
+
+  let updated = 0;
+  let unchanged = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (const result of chunkResults) {
+    if (result.error) {
+      // A failed chunk mirrors the sequential path's per-chunk catch.
+      errors.push(`chunk_${result.chunk_index}: ${result.error}`);
+      continue;
+    }
+    const counts = await upsertEscrows(result.escrows || []);
+    updated += counts.updated;
+    unchanged += counts.unchanged;
+    skipped += counts.skipped;
+    console.log(
+      `[reconciliation]   chunk ${result.chunk_index + 1}/${chunks.length}` +
+        ` (${chunks[result.chunk_index]?.length ?? 0} ids, ${result.duration_ms}ms) —` +
+        ` updated: ${counts.updated}, unchanged: ${counts.unchanged}, skipped: ${counts.skipped}`
+    );
+  }
+
+  return { updated, unchanged, skipped, errors };
+}
+
+/**
+ * Sync all chunks for a set of contract IDs, choosing the Rust parallel path
+ * when RUST_CHUNKS_ENABLED=true and the addon loads, otherwise the sequential
+ * loop. Both paths return the same aggregate shape and identical counts.
+ *
+ * @param {string[]} contractIds  All contract IDs to reconcile.
+ * @returns {Promise<{chunks:number, updated:number, unchanged:number, skipped:number, errors:string[]}>}
+ */
+async function syncAllChunks(contractIds) {
+  const chunks = chunkArray(contractIds, CHUNK_SIZE);
+  if (chunks.length === 0) {
+    return { chunks: 0, updated: 0, unchanged: 0, skipped: 0, errors: [] };
+  }
+
+  // ── Rust parallel path (opt-in) ─────────────────────────────────────────────
+  if (isRustChunkProcessingEnabled()) {
+    try {
+      const r = await syncChunksParallel(chunks);
+      return { chunks: chunks.length, ...r };
+    } catch (err) {
+      // Any addon-level failure degrades safely to the sequential loop below.
+      console.error(
+        `[reconciliation] ⚠️  Parallel chunk path failed, using sequential: ${err.message}`
+      );
+    }
+  }
+
+  // ── Sequential path (default) ───────────────────────────────────────────────
+  let updated = 0;
+  let unchanged = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (let i = 0; i < chunks.length; i++) {
+    try {
+      const r = await syncChunk(chunks[i]);
+      updated += r.updated;
+      unchanged += r.unchanged;
+      skipped += r.skipped;
+      console.log(
+        `[reconciliation]   chunk ${i + 1}/${chunks.length}` +
+          ` (${chunks[i].length} ids) — updated: ${r.updated}, unchanged: ${r.unchanged}, skipped: ${r.skipped}`
+      );
+    } catch (chunkError) {
+      const errMsg = chunkError.message || String(chunkError);
+      console.error(
+        `[reconciliation] ⚠️  Chunk ${i + 1}/${chunks.length} failed: ${errMsg}`
+      );
+      errors.push(`chunk_${i}: ${errMsg}`);
+    }
+  }
+
+  return { chunks: chunks.length, updated, unchanged, skipped, errors };
+}
+
+/**
  * Find escrows not updated by TrustlessWork in the last N days.
  * Uses the partial index idx_trustless_escrows_updated_at for O(log n + k) lookup.
  *
@@ -273,6 +461,12 @@ module.exports = {
   CHUNK_SIZE,
   chunkArray,
   fetchEscrowsByContractIds,
+  upsertEscrows,
   syncChunk,
+  syncChunksParallel,
+  syncAllChunks,
+  isRustChunkProcessingEnabled,
   findStaleEscrows,
+  __setChunkProcessorForTests,
+  __resetChunkProcessorForTests,
 };

--- a/webhook/src/routes/reconciliation/sync-escrows.handler.js
+++ b/webhook/src/routes/reconciliation/sync-escrows.handler.js
@@ -7,21 +7,20 @@
  * Flow
  * ────
  *  1. SELECT all contract_ids, status, balance, marker, approver from public.trustless_work_escrows (tenant='safetrust')
- *  2. Split into chunks of CHUNK_SIZE (50)
- *  3a. For each chunk: call TrustlessWork indexer → upsert changed rows only
- *  3b. Optional Soroban RPC validation pass (Rust crate crates/soroban-reconciler)
- *  4. Chunk-level errors are isolated — one failed chunk never aborts others
- *  5. Detect stale escrows (updated_at older than N days) via indexed lookup
- *  6. Return 200 with full summary JSON (including Soroban metrics) regardless of partial chunk failures
+ *  2. Fetch + upsert every chunk (sequential, or concurrent via the Rust
+ *     chunk-processor addon when RUST_CHUNKS_ENABLED=true) — errors are isolated
+ *  3. Optional Soroban RPC validation pass (Rust crate crates/soroban-reconciler)
+ *  4. Detect stale escrows (updated_at older than N days) via indexed lookup
+ *  5. Return 200 with full summary JSON (including Soroban metrics) regardless of partial chunk failures
  */
 
 const db = require('../../services/db');
 const { hasuraRequest } = require('../../services/hasura');
 const {
+  syncAllChunks,
   chunkArray,
-  syncChunk,
-  findStaleEscrows,
   CHUNK_SIZE,
+  findStaleEscrows,
 } = require('../../lib/reconciliation');
 
 // Rust Soroban reconciler — queries blockchain directly via native addon if available
@@ -85,68 +84,55 @@ async function syncEscrowsHandler(req, res) {
     }
 
     const contractIds = rows.map((r) => r.contract_id);
-    const dbStateMap = Object.fromEntries(
-      rows.map((r) => [r.contract_id, r])
-    );
-    const chunks = chunkArray(contractIds, CHUNK_SIZE);
+    const dbStateMap = Object.fromEntries(rows.map((r) => [r.contract_id, r]));
 
-    let totalUpdated = 0;
-    let totalUnchanged = 0;
-    let totalSkipped = 0;
+    // ── Step 2: TrustlessWork fetch + upsert ──────────────────────────────────
+    // syncAllChunks processes the chunks sequentially, or concurrently via the
+    // Rust chunk-processor addon when RUST_CHUNKS_ENABLED=true, and isolates
+    // per-chunk errors so one failed chunk never aborts the rest.
+    const {
+      chunks: chunkCount,
+      updated: totalUpdated,
+      unchanged: totalUnchanged,
+      skipped: totalSkipped,
+      errors: chunkErrors,
+    } = await syncAllChunks(contractIds);
+
+    // ── Step 3: Optional Soroban RPC validation pass (gated by env var) ───────
+    // Independent of the fetch above: it compares on-chain state against the
+    // pre-sync DB snapshot (dbStateMap) one chunk at a time, and never aborts
+    // the sync. Failures are recorded in chunkErrors.
     let totalSorobanDrift = 0;
     let totalSorobanCorrected = 0;
-    const chunkErrors = [];
 
-    // ── Step 2: Process each chunk independently ──────────────────────────────
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
+    if (SOROBAN_VALIDATION_ENABLED) {
+      const chunks = chunkArray(contractIds, CHUNK_SIZE);
+      for (let i = 0; i < chunks.length; i++) {
+        try {
+          const { drifted, corrected } = await runSorobanValidation(
+            chunks[i], dbStateMap, NETWORK
+          );
+          totalSorobanDrift += drifted;
+          totalSorobanCorrected += corrected;
 
-      try {
-        // Step 3a — TrustlessWork sync (existing, unchanged)
-        const { updated, unchanged, skipped } = await syncChunk(chunk);
-        totalUpdated += updated;
-        totalUnchanged += unchanged;
-        totalSkipped += skipped;
-
-        console.log(
-          `[reconciliation]   chunk ${i + 1}/${chunks.length}` +
-          ` (${chunk.length} ids) — updated: ${updated}, unchanged: ${unchanged}, skipped: ${skipped}`
-        );
-
-        // Step 3b — Soroban RPC validation pass (new — gated by env var)
-        if (SOROBAN_VALIDATION_ENABLED) {
-          try {
-            const chunkResult = await runSorobanValidation(
-              chunk, dbStateMap, NETWORK
+          if (drifted > 0) {
+            console.warn(
+              `[reconciliation] ⚠️  Soroban drift in chunk ${i + 1}:` +
+              ` ${drifted} contracts, ${corrected} auto-corrected`
             );
-            totalSorobanDrift += chunkResult.drifted;
-            totalSorobanCorrected += chunkResult.corrected;
-
-            if (chunkResult.drifted > 0) {
-              console.warn(
-                `[reconciliation] ⚠️  Soroban drift in chunk ${i + 1}:` +
-                ` ${chunkResult.drifted} contracts, ${chunkResult.corrected} auto-corrected`
-              );
-            }
-          } catch (sorobanError) {
-            // Soroban validation failure is non-fatal — TrustlessWork sync still succeeded
-            console.error(
-              `[reconciliation] ⚠️  Soroban validation failed for chunk ${i + 1}:`,
-              sorobanError.message
-            );
-            chunkErrors.push(`soroban_chunk_${i + 1}: ${sorobanError.message}`);
           }
+        } catch (sorobanError) {
+          // Soroban validation failure is non-fatal — the TrustlessWork sync already ran.
+          console.error(
+            `[reconciliation] ⚠️  Soroban validation failed for chunk ${i + 1}:`,
+            sorobanError.message
+          );
+          chunkErrors.push(`soroban_chunk_${i + 1}: ${sorobanError.message}`);
         }
-      } catch (chunkError) {
-        const errMsg = chunkError.message || String(chunkError);
-        console.error(
-          `[reconciliation] ⚠️  Chunk ${i + 1}/${chunks.length} failed: ${errMsg}`
-        );
-        chunkErrors.push(errMsg);
       }
     }
 
-    // ── Step 3: Detect stale escrows (unchanged from current) ─────────────────
+    // ── Step 4: Detect stale escrows (O(log n + k) indexed lookup) ────────────
     const staleContractIds = await findStaleEscrows(STALE_ESCROW_DAYS);
     const staleCount = staleContractIds.length;
 
@@ -159,10 +145,10 @@ async function syncEscrowsHandler(req, res) {
 
     const durationMs = Date.now() - startTime;
 
-    // ── Step 4: Log summary (extended with Soroban metrics) ───────────────────
+    // ── Step 5: Log summary (extended with Soroban metrics) ───────────────────
     console.log(`[reconciliation] ✅ Sync complete in ${durationMs}ms`);
     console.log(`   Total escrows     : ${contractIds.length}`);
-    console.log(`   Chunks            : ${chunks.length}`);
+    console.log(`   Chunks            : ${chunkCount}`);
     console.log(`   Updated rows      : ${totalUpdated}`);
     console.log(`   Unchanged rows    : ${totalUnchanged}`);
     console.log(`   Skipped rows      : ${totalSkipped}`);
@@ -173,11 +159,11 @@ async function syncEscrowsHandler(req, res) {
       console.log(`   Chunk errors      : ${chunkErrors.length}`);
     }
 
-    // ── Step 5: Respond 200 (always — matches existing contract) ─────────────
+    // ── Step 6: Respond 200 (always — matches existing contract) ─────────────
     return res.status(200).json({
       success: true,
       totalEscrows: contractIds.length,
-      chunks: chunks.length,
+      chunks: chunkCount,
       updated: totalUpdated,
       unchanged: totalUnchanged,
       skipped: totalSkipped,

--- a/webhook/src/routes/reconciliation/sync-escrows.handler.js
+++ b/webhook/src/routes/reconciliation/sync-escrows.handler.js
@@ -58,7 +58,7 @@ async function syncEscrowsHandler(req, res) {
   try {
     // ── Step 1: Fetch all known contract IDs ─────────────────────────────────
     const { rows } = await db.query(
-      `SELECT contract_id, status, balance, marker, approver
+      `SELECT contract_id
          FROM public.trustless_work_escrows
         WHERE tenant_id = 'safetrust'`
     );
@@ -84,7 +84,6 @@ async function syncEscrowsHandler(req, res) {
     }
 
     const contractIds = rows.map((r) => r.contract_id);
-    const dbStateMap = Object.fromEntries(rows.map((r) => [r.contract_id, r]));
 
     // ── Step 2: TrustlessWork fetch + upsert ──────────────────────────────────
     // syncAllChunks processes the chunks sequentially, or concurrently via the
@@ -99,13 +98,24 @@ async function syncEscrowsHandler(req, res) {
     } = await syncAllChunks(contractIds);
 
     // ── Step 3: Optional Soroban RPC validation pass (gated by env var) ───────
-    // Independent of the fetch above: it compares on-chain state against the
-    // pre-sync DB snapshot (dbStateMap) one chunk at a time, and never aborts
-    // the sync. Failures are recorded in chunkErrors.
+    // Compares on-chain state against the DB, one chunk at a time, and never
+    // aborts the sync. The snapshot is read AFTER Step 2 so drift is measured
+    // against the just-synced rows (not a pre-sync snapshot): this avoids both
+    // overstating drift and reverting a freshly-synced row on a stale compare.
+    // Failures are recorded in chunkErrors.
     let totalSorobanDrift = 0;
     let totalSorobanCorrected = 0;
 
     if (SOROBAN_VALIDATION_ENABLED) {
+      const { rows: currentRows } = await db.query(
+        `SELECT contract_id, status, balance, marker, approver
+           FROM public.trustless_work_escrows
+          WHERE tenant_id = 'safetrust'`
+      );
+      const dbStateMap = Object.fromEntries(
+        currentRows.map((r) => [r.contract_id, r])
+      );
+
       const chunks = chunkArray(contractIds, CHUNK_SIZE);
       for (let i = 0; i < chunks.length; i++) {
         try {


### PR DESCRIPTION


Closes #548

## What this does

The reconciliation endpoint (`POST /reconciliation/sync-escrows`) fetches escrow
state from the TrustlessWork indexer in batches of 50 contract IDs. Today those
batches are fetched one after another in a JavaScript `for` loop. Each batch is
a separate HTTP request, so with 10 batches the endpoint spends roughly ten
request round-trips of wall-clock time waiting on the network, one batch at a
time.

This PR adds a Rust addon, `chunk-processor`, that fetches the batches
concurrently on a Tokio runtime. It is turned on with a single environment flag,
`RUST_CHUNKS_ENABLED=true`. When the flag is off (the default), nothing changes:
the old sequential loop runs exactly as before and the addon is never even
loaded.

## Why Rust here

The work is network-bound and every batch is independent, which is the ideal
shape for bounded concurrency. Tokio drives many in-flight HTTP requests on a
small thread pool, so instead of paying `N` round-trips back to back we pay
about one round-trip plus a little overhead, capped by how many requests we
allow at once. The database writes stay in JavaScript; the addon only handles
the concurrent fetch and hands the escrow records back untouched.

## How it works

New crate: `crates/chunk-processor/` (Neon / Node-API v6 addon).

It exports one function:

```
processChunksParallel(chunksJson, apiUrl, apiKey, maxConcurrency, timeoutMs) => string
```

`chunksJson` is a JSON `string[][]` (the batches). The return value is a JSON
array with one entry per batch: `{ chunk_index, fetched, duration_ms, error, escrows }`.

Design decisions worth calling out:

* Bounded, streaming concurrency. It uses `futures::buffer_unordered`, so a new
  request starts the moment a slot frees up. A fixed "batch of 5, wait, next
  batch of 5" scheme would stall a whole wave on its slowest request; this does
  not.
* Hard per-batch timeout, enforced twice. The reqwest per-request timeout covers
  the normal case, and an outer `tokio::time::timeout` guarantees a batch always
  resolves within `CHUNK_TIMEOUT_MS` even if something stalls before the request
  is fully underway.
* Failure isolation. A batch that fails (HTTP error, timeout, bad response) is
  recorded in its own `error` field and never aborts the others. The addon only
  throws for a genuine caller mistake, like malformed `chunksJson`.
* Lossless pass-through. Escrow records are returned to JavaScript exactly as the
  indexer sent them, so the existing UPSERT keeps writing every column it wrote
  before (`amount`, `roles.marker/approver/releaser`, `escrowType`, and so on).
* Response-shape tolerance. The indexer sometimes returns `{ "escrows": [...] }`
  and sometimes a bare array. Both are handled, matching the current JS helper.
* Shared runtime and connection-pooling HTTP client, created once and reused,
  instead of rebuilding them on every call.
* rustls for TLS, so there is no system OpenSSL dependency and the crate builds
  cleanly on the Alpine/musl image used in `webhook/Dockerfile`.

## JavaScript integration

`webhook/src/lib/reconciliation.js`:

* Pulled the per-record UPSERT out of `syncChunk` into a shared `upsertEscrows`
  helper, so the sequential path and the parallel path write to the database
  through the exact same code with the same counting.
* Added `syncChunksParallel` (calls the addon, then upserts each batch) and
  `syncAllChunks` (picks the parallel or sequential path). If the flag is on but
  the addon fails to load for any reason, it logs a warning and falls back to the
  sequential loop, so the endpoint cannot break because of the native module.
* Added the config it reads: `RUST_CHUNKS_ENABLED`, `CHUNK_CONCURRENCY`,
  `CHUNK_TIMEOUT_MS`.

`webhook/src/routes/reconciliation/sync-escrows.handler.js` now calls
`syncAllChunks`. The response JSON is unchanged: same fields, and `errors` is
still a count of failed batches.

## Where I departed from the sample code in the issue

The snippet in the issue was a sketch. Wiring it into the real service needed a
few corrections:

1. Endpoint, env vars, and auth. The live code calls
   `/helper/get-escrows-by-contract-ids` with an `x-api-key` header and reads
   `TRUSTLESS_WORK_API_URL` / `TRUSTLESS_WORK_API_KEY`. The sketch used a
   different path and env names that do not exist in this repo.
2. Lossless records. The sketch flattened each escrow to
   `{ contract_id, status, balance }`. Using that shape would have quietly
   dropped `amount`, the `roles` object, and `escrowType` from the database
   write. The addon returns the full record instead.
3. neon 1.x. I matched the version already used by the `webhook-verifier` crate
   so the whole workspace shares one lockfile. The `0.10` in the issue predates
   that crate.
4. Concurrency and timeout implementation, as described above (streaming
   `buffer_unordered` and a double timeout, plus a shared runtime and client).


## Measured before and after

`node crates/chunk-processor/benchmark.js` runs both paths against a local mock
indexer with 300 ms of latency per request, 500 IDs total, batch size 50. The
mock runs in a separate process on purpose: `processChunksParallel` blocks the
Node event loop while it runs, so an in-process server could not answer its own
requests. The script also asserts that both paths fetch every ID, that records
come back intact, and that an unreachable host produces one error per batch
without throwing.

| Scenario | batches | concurrency | sequential | parallel | speedup |
| --- | :---: | :---: | ---: | ---: | :---: |
| Default concurrency | 10 | 5 | 3510 ms | 707 ms | 4.96x |
| Concurrency equal to batch count | 10 | 10 | 3262 ms | 402 ms | 8.11x |
| Small run (N = 3) | 3 | 3 | 1062 ms | 321 ms | 3.31x |

At concurrency 10 the measured 8.11x lands close to the 9x the issue projected
for N = 10 under Gustafson scaling; the small gap is runtime and IPC overhead in
the benchmark harness. The default of 5 still gives about 5x at N = 10 while
keeping a lid on how many simultaneous requests hit the indexer.


Benchmark: sequential vs parallel screenshot:
<img width="658" height="703" alt="st2" src="https://github.com/user-attachments/assets/16853dee-7dfa-417a-8d5c-eeff7ade72ec" />


## Tests

* `crates/chunk-processor/src/lib.rs` has 10 unit tests covering batch parsing,
  the two response shapes, unexpected-shape rejection, URL building, failure
  isolation with correct ordering, and clamping `maxConcurrency` of 0 to 1.
* `webhook/src/lib/__tests__/reconciliation-parallel.test.js` (new) covers
  `upsertEscrows`, the parallel glue, path selection on the flag, and the
  fallback to sequential when the addon is unavailable. A small test seam lets
  these run without a native build by injecting a fake addon.
* While here I fixed a latent issue in the existing
  `webhook/src/lib/__tests__/reconciliation.test.js`: `jest.mock('https')` did
  not produce a mock `request` function on Node 18+, so that suite threw on the
  project's own Node 24. Switched it to an explicit factory.

Cargo tests screenshot:
<img width="1020" height="475" alt="st1" src="https://github.com/user-attachments/assets/93e89161-7de7-47cd-9a29-b01b3af04d11" />


## How to run it

```bash
# build the addon (workspace build already covers it; copy-native drops the .node)
cargo build --release -p chunk-processor
node crates/chunk-processor/copy-native.js

# rust tests
cargo test -p chunk-processor

# benchmark (needs Node 18+)
node crates/chunk-processor/benchmark.js
BENCH_CONCURRENCY=10 node crates/chunk-processor/benchmark.js
BENCH_CHUNKS=3 BENCH_CONCURRENCY=3 node crates/chunk-processor/benchmark.js
```

Enable the parallel path at runtime:

```bash
RUST_CHUNKS_ENABLED=true
CHUNK_CONCURRENCY=5
CHUNK_TIMEOUT_MS=5000
```

## Acceptance criteria

- [x] `cargo build --release` passes with zero warnings (built with `-D warnings`)
- [x] `RUST_CHUNKS_ENABLED=false` (default) keeps existing behaviour
- [x] `RUST_CHUNKS_ENABLED=true` fetches batches concurrently via Tokio
- [x] Per-batch timeout enforced at `CHUNK_TIMEOUT_MS`
- [x] A failed batch is captured in the result and does not abort the others
- [x] Response JSON unchanged; `errors` reflects the failed-batch count
- [x] `durationMs` measurably lower at 3 or more batches with the flag on
- [x] Karate tests unaffected (the default path is untouched)
- [x] PR includes the measured before/after


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in parallel processing for escrow reconciliation with configurable concurrency limits and request timeouts.
  * Preserved sequential fallback when parallel processing is disabled or unavailable.
  * Added per-chunk error isolation, detailed synchronization results, and support for multiple response formats.
  * Added optional Soroban validation with discrepancy reporting and correction support.

* **Documentation**
  * Added setup, configuration, build, testing, and benchmarking guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->