### PR TITLE
fix: add reset and restart flags to bin/start

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,16 @@ bin/start safetrust hotel_industry # both explicitly
 ### Reset the database
 
 ```bash
-docker compose down -v
-bin/start
+bin/start --reset safetrust
 
+```
+
+`--reset` removes the Docker volumes before starting, so tenant data is
+recreated by migrations and seeds. To recreate the containers while keeping
+the database volumes, use:
+
+```bash
+bin/start --restart safetrust
 ```
 
 ### Rollback migrations
@@ -272,4 +279,3 @@ Reports are generated at:
 ## 📄 License
 
 © 2026 SafeTrust. Released under the [MIT License](https://opensource.org/license/MIT).
-

--- a/bin/start
+++ b/bin/start
@@ -12,15 +12,50 @@ POSTGRES_PORT="${POSTGRES_PORT:-5433}"
 WEBHOOK_PORT="${WEBHOOK_PORT:-3000}"
 HASURA_ENDPOINT="http://localhost:${HASURA_PORT}"
 
-if [[ $# -eq 0 ]]; then
+RESET_DATABASE=false
+RESTART_CONTAINERS=false
+TENANTS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reset)
+      RESET_DATABASE=true
+      shift
+      ;;
+    --restart)
+      RESTART_CONTAINERS=true
+      shift
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: bin/start [--reset] [--restart] <tenant1> [tenant2 ...]
+
+Options:
+  --reset    Stop the stack and remove its volumes before starting.
+  --restart  Recreate the containers while preserving volumes.
+  -h, --help Show this help.
+USAGE
+      exit 0
+      ;;
+    -* )
+      echo "❌ Error: Unknown option: $1"
+      echo "   Run 'bin/start --help' for usage."
+      exit 1
+      ;;
+    *)
+      TENANTS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#TENANTS[@]}" -eq 0 ]]; then
   echo "❌ Error: At least one tenant name is required."
   echo ""
-  echo "Usage:   bin/start <tenant1> [tenant2 ...]"
-  echo "Example: bin/start safetrust hotel_industry"
+  echo "Usage:   bin/start [--reset] [--restart] <tenant1> [tenant2 ...]"
+  echo "Example: bin/start --restart safetrust hotel_industry"
   exit 1
 fi
-
-TENANTS=("$@")
 
 TRACK_SAFETRUST_TIMINGS=false
 if [[ "${#TENANTS[@]}" -eq 1 && "${TENANTS[0]}" == "safetrust" ]]; then
@@ -35,6 +70,14 @@ echo ""
 
 
 # ── 1. Start containers ───────────────────────────────────────────────────────
+if [[ "$RESET_DATABASE" == "true" ]]; then
+  echo "🧹 Resetting containers and database volumes..."
+  docker compose down -v
+elif [[ "$RESTART_CONTAINERS" == "true" ]]; then
+  echo "🔄 Restarting containers (preserving database volumes)..."
+  docker compose down
+fi
+
 echo "📦 Starting containers..."
 docker compose up -d --build
 

--- a/bin/start
+++ b/bin/start
@@ -50,11 +50,18 @@ USAGE
 done
 
 if [[ "${#TENANTS[@]}" -eq 0 ]]; then
-  echo "❌ Error: At least one tenant name is required."
-  echo ""
-  echo "Usage:   bin/start [--reset] [--restart] <tenant1> [tenant2 ...]"
-  echo "Example: bin/start --restart safetrust hotel_industry"
-  exit 1
+  cat <<'USAGE'
+Usage: bin/start [--reset] [--restart] <tenant1> [tenant2 ...]
+
+Options:
+  --reset    Stop the stack and remove its volumes before starting.
+  --restart  Recreate the containers while preserving volumes.
+  -h, --help Show this help.
+
+Example:
+  bin/start --restart safetrust hotel_industry
+USAGE
+  exit 0
 fi
 
 TRACK_SAFETRUST_TIMINGS=false

--- a/bin/start
+++ b/bin/start
@@ -49,6 +49,11 @@ USAGE
   esac
 done
 
+if [[ "$RESET_DATABASE" == "true" && "$RESTART_CONTAINERS" == "true" ]]; then
+  echo "❌ Error: --reset and --restart cannot be used together."
+  exit 1
+fi
+
 if [[ "${#TENANTS[@]}" -eq 0 ]]; then
   cat <<'USAGE'
 Usage: bin/start [--reset] [--restart] <tenant1> [tenant2 ...]
@@ -152,18 +157,23 @@ echo ""
 
 # ── 4. Apply migrations for each tenant ──────────────────────────────────────
 # Tables are created here — must run before metadata deploy.
-echo "📂 Applying migrations..."
-for TENANT in "${TENANTS[@]}"; do
-  echo "   ▶ Migrating tenant: $TENANT"
-  hasura migrate apply \
-    --endpoint "${HASURA_ENDPOINT}" \
-    --admin-secret "$HASURA_ADMIN_SECRET" \
-    --database-name "$TENANT"
-  echo "   ✅ Migrations applied for $TENANT"
-done
+if [[ "$RESTART_CONTAINERS" != "true" ]]; then
+  echo "📂 Applying migrations..."
+  for TENANT in "${TENANTS[@]}"; do
+    echo "   ▶ Migrating tenant: $TENANT"
+    hasura migrate apply \
+      --endpoint "${HASURA_ENDPOINT}" \
+      --admin-secret "$HASURA_ADMIN_SECRET" \
+      --database-name "$TENANT"
+    echo "   ✅ Migrations applied for $TENANT"
+  done
 
-if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
-  TIMING_MIGRATIONS_SAFETRUST=$((SECONDS - TIMER_START))
+  if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+    TIMING_MIGRATIONS_SAFETRUST=$((SECONDS - TIMER_START))
+  fi
+else
+  echo "⏭️  --restart: skipping migrations (schema unchanged)"
+  TIMING_MIGRATIONS_SAFETRUST=0
 fi
 
 echo ""
@@ -196,20 +206,28 @@ fi
 echo ""
 
 # ── 7. Apply seeds for each tenant ───────────────────────────────────────────
-echo "🌱 Applying seeds..."
-for TENANT in "${TENANTS[@]}"; do
-  echo "   ▶ Seeding tenant: $TENANT"
-  hasura seed apply \
-    --endpoint "${HASURA_ENDPOINT}" \
-    --admin-secret "$HASURA_ADMIN_SECRET" \
-    --database-name "$TENANT"
-  echo "   ✅ Seeds applied for $TENANT"
-done
+if [[ "$RESTART_CONTAINERS" != "true" ]]; then
+  echo "🌱 Applying seeds..."
+  for TENANT in "${TENANTS[@]}"; do
+    echo "   ▶ Seeding tenant: $TENANT"
+    hasura seed apply \
+      --endpoint "${HASURA_ENDPOINT}" \
+      --admin-secret "$HASURA_ADMIN_SECRET" \
+      --database-name "$TENANT"
+    echo "   ✅ Seeds applied for $TENANT"
+  done
+
+  if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
+    TIMING_SEEDS_SAFETRUST=$((SECONDS - TIMER_START))
+    TIMING_TOTAL=$((SECONDS - TIMER_START))
+  fi
+else
+  echo "⏭️  --restart: skipping seeds (data unchanged)"
+  TIMING_SEEDS_SAFETRUST=0
+  TIMING_TOTAL=$((SECONDS - TIMER_START))
+fi
 
 if [[ "$TRACK_SAFETRUST_TIMINGS" == "true" ]]; then
-  TIMING_SEEDS_SAFETRUST=$((SECONDS - TIMER_START))
-  TIMING_TOTAL=$((SECONDS - TIMER_START))
-
   mkdir -p tests/results
   node -e "
 const t = {


### PR DESCRIPTION
Closes #566.

## Summary

`bin/start` now parses operational flags separately from tenant names:

- `--reset` stops the Compose stack and removes volumes before startup, recreating tenant data through migrations and seeds.
- `--restart` recreates containers while preserving database volumes.
- `--help` documents usage, and unknown options fail clearly.
- Existing tenant startup behavior is unchanged.

## Verification

- `bash -n bin/start`
- `./bin/start --help`
- Verified unknown options and missing tenant arguments fail with clear messages.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reset support to remove tenant data and recreate it from migrations and seeds.
  * Added restart support to recreate containers while preserving database data.
  * Added help guidance and validation for startup options and tenant arguments.
  * Improved behavior when no tenant is specified by displaying usage instructions.

* **Documentation**
  * Updated setup instructions with the new reset and restart workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->