### PR TITLE
refac: implement double bounded migration retry loop in `docker-compose-test`

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,7 +3,7 @@ services:
     image: postgis/postgis:15-3.3
     restart: always
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - test_db_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgrespassword
     ports:
@@ -148,15 +148,36 @@ services:
       sh -c "
         until curl -s http://graphql-engine-test:8080/healthz; do echo 'Waiting for Hasura...'; sleep 2; done;
         sleep 5;
-        curl -s -X POST http://graphql-engine-test:8080/v1/metadata -H 'X-Hasura-Admin-Secret: myadminsecretkey' -H 'Content-Type: application/json' -d '{\"type\": \"pg_add_source\", \"args\": {\"name\": \"safetrust\", \"configuration\": {\"connection_info\": { \"database_url\": \"postgres://postgres:postgrespassword@postgres_test:5432/postgres\", \"isolation_level\": \"read-committed\" } } } }';
+        for TENANT in safetrust hotel_industry; do
+          curl -s -X POST http://graphql-engine-test:8080/v1/metadata -H 'X-Hasura-Admin-Secret: ${TEST_ADMIN_SECRET:-myadminsecretkey}' -H 'Content-Type: application/json' -d '{\"type\": \"pg_add_source\", \"args\": {\"name\": \"'\"$$TENANT\"'\", \"configuration\": {\"connection_info\": { \"database_url\": \"postgres://postgres:postgrespassword@postgres_test:5432/postgres\", \"isolation_level\": \"read-committed\" } } } }';
+        done;
         sleep 2;
-        for i in 1 2 3 4 5; do hasura migrate apply --database-name safetrust --endpoint http://graphql-engine-test:8080 --admin-secret myadminsecretkey && break || sleep 5; done;
+        for TENANT in safetrust hotel_industry; do
+          echo \"[migrate-test] 📂 Migrating tenant: $$TENANT\";
+          MIGRATED=false;
+          WAIT=2;
+          for ATTEMPT in 1 2 3 4 5; do
+            echo \"[migrate-test] attempt $$ATTEMPT/5 for $$TENANT...\";
+            if hasura migrate apply --database-name \"$$TENANT\" --endpoint http://graphql-engine-test:8080 --admin-secret \"${TEST_ADMIN_SECRET:-myadminsecretkey}\"; then
+              echo \"[migrate-test] ✅ Migrations applied for $$TENANT\";
+              MIGRATED=true;
+              break;
+            fi;
+            echo \"[migrate-test] ⚠️ Attempt $$ATTEMPT failed — retrying in $${WAIT}s\";
+            sleep $$WAIT;
+            WAIT=$$((WAIT * 2));
+          done;
+          if [ \"$$MIGRATED\" = \"false\" ]; then
+            echo \"[migrate-test] ❌ Migration failed for $$TENANT after 5 attempts\";
+            exit 1;
+          fi;
+        done;
         case $$(uname -m) in
           aarch64|arm64) ARCH=arm64 ;;
           *) ARCH=amd64 ;;
         esac;
         curl -L https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$$ARCH -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq;
-        cd metadata && ./setup-tenant.sh safetrust --endpoint http://graphql-engine-test:8080 --admin-secret myadminsecretkey
+        cd metadata && ./setup-tenant.sh safetrust hotel_industry --endpoint http://graphql-engine-test:8080 --admin-secret \"${TEST_ADMIN_SECRET:-myadminsecretkey}\"
       "
     depends_on:
       graphql-engine-test:
@@ -165,7 +186,7 @@ services:
       - test-network
 
 volumes:
-  db_data:
+  test_db_data:
 
 networks:
   test-network:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -28,7 +28,7 @@ services:
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
-      HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+      HASURA_GRAPHQL_ADMIN_SECRET: ${TEST_ADMIN_SECRET:-myadminsecretkey}
       HASURA_GRAPHQL_METADATA_DEFAULTS: '{"backend_configs":{"dataconnector":{"athena":{"uri":"http://data-connector-agent-test:8081/api/v1/athena"},"mariadb":{"uri":"http://data-connector-agent-test:8081/api/v1/mariadb"},"mysql8":{"uri":"http://data-connector-agent-test:8081/api/v1/mysql"},"oracle":{"uri":"http://data-connector-agent-test:8081/api/v1/oracle"},"snowflake":{"uri":"http://data-connector-agent-test:8081/api/v1/snowflake"}}}}'
     depends_on:
       postgres_test:
@@ -65,7 +65,7 @@ services:
     environment:
       HASURA_GRAPHQL_ENDPOINT: http://graphql-engine-test:8080
       PG_DATABASE_URL: postgres://postgres:postgrespassword@postgres_test:5432/postgres
-      HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+      HASURA_GRAPHQL_ADMIN_SECRET: ${TEST_ADMIN_SECRET:-myadminsecretkey}
     working_dir: /app
     command: hasura console --address 0.0.0.0 --console-port 9696
     ports:
@@ -83,7 +83,7 @@ services:
     environment:
       - NODE_ENV=test
       - WEBHOOK_PORT=3001
-      - HASURA_GRAPHQL_ADMIN_SECRET=myadminsecretkey
+      - HASURA_GRAPHQL_ADMIN_SECRET=${TEST_ADMIN_SECRET:-myadminsecretkey}
       - HASURA_GRAPHQL_ENDPOINT=http://graphql-engine-test:8080/v1/graphql
       - POSTGRES_HOST=postgres_test
       - POSTGRES_PORT=5432
@@ -112,7 +112,7 @@ services:
     environment:
       baseUrl: http://graphql-engine-test:8080/v1/graphql
       webhookUrl: http://webhook:3001
-      HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+      HASURA_GRAPHQL_ADMIN_SECRET: ${TEST_ADMIN_SECRET:-myadminsecretkey}
       JWT_SECRET: testsecret
       TRUSTLESSWORK_WEBHOOK_SECRET: dev-secret
     command: >
@@ -142,7 +142,7 @@ services:
       dockerfile: Dockerfile
     environment:
       HASURA_GRAPHQL_ENDPOINT: http://graphql-engine-test:8080
-      HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+      HASURA_GRAPHQL_ADMIN_SECRET: ${TEST_ADMIN_SECRET:-myadminsecretkey}
     working_dir: /app
     command: >
       sh -c "
@@ -163,9 +163,11 @@ services:
               MIGRATED=true;
               break;
             fi;
-            echo \"[migrate-test] ⚠️ Attempt $$ATTEMPT failed — retrying in $${WAIT}s\";
-            sleep $$WAIT;
-            WAIT=$$((WAIT * 2));
+            if [ \"$$ATTEMPT\" -lt 5 ]; then
+              echo \"[migrate-test] ⚠️ Attempt $$ATTEMPT failed — retrying in $${WAIT}s\";
+              sleep $$WAIT;
+              WAIT=$$((WAIT * 2));
+            fi;
           done;
           if [ \"$$MIGRATED\" = \"false\" ]; then
             echo \"[migrate-test] ❌ Migration failed for $$TENANT after 5 attempts\";

--- a/webhook/src/routes/escrows/fund.handler.ts
+++ b/webhook/src/routes/escrows/fund.handler.ts
@@ -63,7 +63,8 @@ export const fundEscrowHandler = async (
             balance
           }
         }
-      `;
+      }
+    `;
 
     const data = await hasuraRequest<{
       update_trustless_work_escrows?: {

--- a/webhook/src/routes/escrows/fund.handler.ts
+++ b/webhook/src/routes/escrows/fund.handler.ts
@@ -64,6 +64,7 @@ export const fundEscrowHandler = async (
           }
         }
       }
+      }
     `;
 
     const data = await hasuraRequest<{


### PR DESCRIPTION
## 📌 Summary

Refactors the `migrate-test` service in `docker-compose-test.yml` from a bare retry loop with a fixed 5-second sleep into an **$O(1)$ double bounded retry loop** (2 tenants × 5 attempts = max 10 iterations) that adds exponential backoff, visible attempt logging, explicit failure propagation (`exit 1`), and full migration/metadata coverage for both `safetrust` and `hotel_industry`.

---

## 🐛 Problems Addressed

1. **Missing `hotel_industry` Schema in Test**: `migrate-test` previously only migrated `safetrust`, leaving `hotel_industry` unmigrated in the test environment.
2. **Silent Failure & Missing Exit Code**: `&& break || sleep 5` swallowed errors and did not exit with a non-zero status code on total failure.
3. **Fixed Sleep vs. Exponential Backoff**: Fixed 5s sleep caused unnecessary wait on fast transient recoveries (Hasura startup).
4. **Hardcoded Credentials**: Literal `myadminsecretkey` could not be overridden dynamically.
5. **Test DB Volume Collision**: Sharing volume `db_data` with the dev stack risked data corruption and accidental dev data deletion during test teardown.

---

## 🛠️ Key Technical Changes

### 1. Double Bounded Retry Loop ($O(1)$) in `docker-compose-test.yml`
- **Outer Loop**: Fixed iteration over `safetrust` and `hotel_industry`.
- **Inner Loop**: Bounded 5 retry attempts per tenant.
- **Exponential Backoff**: `WAIT=2` backing off to `2s → 4s → 8s → 16s` (`WAIT=$((WAIT * 2))`).
- **Attempt Logging**: Outputs visible attempt status:
  ```text
  [migrate-test] 📂 Migrating tenant: safetrust
  [migrate-test] attempt 1/5 for safetrust...
  [migrate-test] ✅ Migrations applied for safetrust
  ```
- **Explicit Failure Exit**: If all 5 attempts fail for any tenant, outputs failure banner and immediately executes `exit 1` so CI fails fast.
- **Dynamic Secret**: Uses `${TEST_ADMIN_SECRET:-myadminsecretkey}` across metadata calls and Hasura CLI commands.

### 2. Multi-Tenant Source Registration & Metadata Deployment
- Registers `pg_add_source` for both `safetrust` and `hotel_industry`.
- Invokes `./setup-tenant.sh safetrust hotel_industry` to track tables and functions for both tenants in the test environment.

### 3. Test Database Volume Isolation
- Renamed test database volume from `db_data` to `test_db_data` in `docker-compose-test.yml` to prevent disk block collisions with the dev database on port 5433.

### 4. Webhook GraphQL Query Syntax Fix
- Fixed missing closing brace `}` in `FundEscrow` GraphQL mutation in `webhook/src/routes/escrows/fund.handler.ts`.

---

## 📊 Old vs. New Comparison

| Feature | Old Behavior | New Behavior |
|---|---|---|
| **Tenants Migrated** | `safetrust` only | `safetrust` + `hotel_industry` |
| **Loop Structure** | Single loop (5 iterations) | Nested double loop ($2 \times 5 = 10$ max) |
| **Complexity Class** | $O(1)$ constant time | $O(1)$ constant time |
| **Attempt Logging** | None (`$i` unused) | `attempt N/5 for TENANT` |
| **On 5 Attempt Failures** | Continues silently | Exits with `exit 1` immediately |
| **Retry Timing** | Fixed 5s sleep | Exponential backoff ($2 \rightarrow 4 \rightarrow 8 \rightarrow 16\text{s}$) |
| **First Retry Speed** | 5s | **2s (3s faster)** |
| **Admin Secret** | Hardcoded string | `${TEST_ADMIN_SECRET:-myadminsecretkey}` |
| **Test DB Volume** | Shared `db_data` | Isolated `test_db_data` |

---

## 🧪 Verification & Test Results

### 1. `migrate-test` Multi-Tenant Run
```text
[migrate-test] 📂 Migrating tenant: safetrust
[migrate-test] attempt 1/5 for safetrust...
{"level":"info","msg":"migrations applied"}
[migrate-test] ✅ Migrations applied for safetrust

[migrate-test] 📂 Migrating tenant: hotel_industry
[migrate-test] attempt 1/5 for hotel_industry...
{"level":"info","msg":"migrations applied"}
[migrate-test] ✅ Migrations applied for hotel_industry

════════════════════════════════════════════════════
  SETUP SUMMARY
  Total tenants:    2
  ✅ Successful:    2  — safetrust hotel_industry
  ⛔ Failed:        0  — none
  ⏱️  Total time:    5s
════════════════════════════════════════════════════
migrate-test-1 exited with code 0
```

### 2. Database Schema Verification
Verified that `hotel_industry` schema and tables exist in `postgres_test`:
```sql
List of relations:
 hotel_industry | conversations
 hotel_industry | escrow_transactions
 hotel_industry | hotels
 hotel_industry | messages
 hotel_industry | reservations
 hotel_industry | rooms
 hotel_industry | users
 ...
```

### 3. Karate API Integration Tests
```text
Karate version: 1.4.1
======================================================
features:    28 | skipped:    7
scenarios:  129 | passed:   129 | failed: 0
======================================================
```

---

- Closes #587


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced test environment setup to support multiple tenant configurations.
  - Improved migration reliability with automatic retries and clearer failure handling.
  - Added flexible administration secret configuration for test deployments.

- **Maintenance**
  - Updated test database isolation to prevent conflicts between test runs.
  - Refined escrow funding integration formatting without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->