### PR TITLE
feat(safetrust): SafeTrust tenant schema namespace migration via init sql strategy

### DIFF
--- a/metadata/tenants/safetrust/databases/functions/find_apartments_by_owner_function.yaml
+++ b/metadata/tenants/safetrust/databases/functions/find_apartments_by_owner_function.yaml
@@ -1,3 +1,3 @@
 function:
-  schema: public
+  schema: safetrust
   name: find_apartments_by_owner

--- a/metadata/tenants/safetrust/databases/functions/get_apartments_in_bounds_function.yaml
+++ b/metadata/tenants/safetrust/databases/functions/get_apartments_in_bounds_function.yaml
@@ -1,19 +1,19 @@
 function:
-  schema: public
+  schema: safetrust
   name: get_apartments_in_bounds
 definition: |
-  CREATE OR REPLACE FUNCTION public.get_apartments_in_bounds(
+  CREATE OR REPLACE FUNCTION safetrust.get_apartments_in_bounds(
     min_lat FLOAT,
     max_lat FLOAT,
     min_lng FLOAT,
     max_lng FLOAT
   )
-  RETURNS SETOF public.apartments
+  RETURNS SETOF safetrust.apartments
   LANGUAGE sql
   STABLE
   AS $$
     SELECT a.*
-    FROM public.apartments a
+    FROM safetrust.apartments a
     WHERE
       a.deleted_at IS NULL
       AND a.is_available = true

--- a/metadata/tenants/safetrust/databases/functions/get_escrow_analytics_by_day_function.yaml
+++ b/metadata/tenants/safetrust/databases/functions/get_escrow_analytics_by_day_function.yaml
@@ -1,5 +1,5 @@
 function:
-  schema: public
+  schema: safetrust
   name: get_escrow_analytics_by_day
 configuration:
   exposed_as: query

--- a/metadata/tenants/safetrust/databases/functions/get_escrow_status_summary_function.yaml
+++ b/metadata/tenants/safetrust/databases/functions/get_escrow_status_summary_function.yaml
@@ -1,5 +1,5 @@
 function:
-  schema: public
+  schema: safetrust
   name: get_escrow_status_summary
 configuration:
   exposed_as: query

--- a/metadata/tenants/safetrust/databases/functions/search_apartments_function.yaml
+++ b/metadata/tenants/safetrust/databases/functions/search_apartments_function.yaml
@@ -1,3 +1,3 @@
 function:
-  schema: public
+  schema: safetrust
   name: search_apartments

--- a/metadata/tenants/safetrust/databases/functions/track_nearby_apartments_function.yaml
+++ b/metadata/tenants/safetrust/databases/functions/track_nearby_apartments_function.yaml
@@ -1,18 +1,18 @@
 function:
-  schema: public
+  schema: safetrust
   name: find_nearby_apartments
 definition: |
-  CREATE OR REPLACE FUNCTION public.find_nearby_apartments(
+  CREATE OR REPLACE FUNCTION safetrust.find_nearby_apartments(
     lat FLOAT,
     lng FLOAT,
     radius_meters FLOAT DEFAULT 5000
   )
-  RETURNS SETOF public.apartments
+  RETURNS SETOF safetrust.apartments
   LANGUAGE sql
   STABLE
   AS $$
     SELECT a.*
-    FROM public.apartments a
+    FROM safetrust.apartments a
     WHERE
       a.deleted_at IS NULL
       AND a.is_available = true

--- a/metadata/tenants/safetrust/databases/tables/public_apartment_images.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_apartment_images.yaml
@@ -1,6 +1,6 @@
 table:
   name: apartment_images
-  schema: public
+  schema: safetrust
   
 object_relationships:
   - name: apartment

--- a/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_apartments.yaml
@@ -1,6 +1,6 @@
 table:
   name: apartments
-  schema: public
+  schema: safetrust
 object_relationships:
   - name: owner
     using:
@@ -12,14 +12,14 @@ array_relationships:
         column: apartment_id
         table:
           name: bid_requests
-          schema: public
+          schema: safetrust
   - name: apartment_images
     using:
       foreign_key_constraint_on:
         column: apartment_id
         table:
           name: apartment_images
-          schema: public
+          schema: safetrust
 select_permissions:
   - role: anonymous
     permission:

--- a/metadata/tenants/safetrust/databases/tables/public_bid_requests.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_bid_requests.yaml
@@ -1,6 +1,6 @@
 table:
   name: bid_requests
-  schema: public
+  schema: safetrust
 object_relationships:
   - name: apartment
     using:
@@ -15,7 +15,7 @@ array_relationships:
         column: bid_request_id
         table:
           name: bid_status_histories
-          schema: public
+          schema: safetrust
 select_permissions:
   - role: anonymous
     permission:

--- a/metadata/tenants/safetrust/databases/tables/public_bid_status_histories.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_bid_status_histories.yaml
@@ -1,6 +1,6 @@
 table:
   name: bid_status_histories
-  schema: public
+  schema: safetrust
 object_relationships:
   - name: bid_request
     using:

--- a/metadata/tenants/safetrust/databases/tables/public_conversations.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_conversations.yaml
@@ -1,6 +1,6 @@
 table:
   name: conversations
-  schema: public
+  schema: safetrust
 object_relationships:
   - name: apartment
     using:
@@ -21,7 +21,7 @@ array_relationships:
         column: conversation_id
         table:
           name: messages
-          schema: public
+          schema: safetrust
 select_permissions:
   - role: safetrust
     permission:

--- a/metadata/tenants/safetrust/databases/tables/public_escrow_analytics_by_day.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_escrow_analytics_by_day.yaml
@@ -1,3 +1,3 @@
 table:
   name: escrow_analytics_by_day
-  schema: public
+  schema: safetrust

--- a/metadata/tenants/safetrust/databases/tables/public_escrow_milestones.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_escrow_milestones.yaml
@@ -1,6 +1,6 @@
 table:
   name: escrow_milestones
-  schema: public
+  schema: safetrust
 configuration:
   column_config:
     escrow_id:

--- a/metadata/tenants/safetrust/databases/tables/public_escrow_pending_approvals.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_escrow_pending_approvals.yaml
@@ -1,6 +1,6 @@
 table:
   name: escrow_pending_approvals
-  schema: public
+  schema: safetrust
 event_triggers:
   - name: on_escrow_approval_required
     definition:

--- a/metadata/tenants/safetrust/databases/tables/public_escrow_status_summary.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_escrow_status_summary.yaml
@@ -1,3 +1,3 @@
 table:
   name: escrow_status_summary
-  schema: public
+  schema: safetrust

--- a/metadata/tenants/safetrust/databases/tables/public_escrow_transactions.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_escrow_transactions.yaml
@@ -1,6 +1,6 @@
 table:
   name: escrow_transactions
-  schema: public
+  schema: safetrust
   columns:
     - name: id
       type: uuid

--- a/metadata/tenants/safetrust/databases/tables/public_messages.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_messages.yaml
@@ -1,6 +1,6 @@
 table:
   name: messages
-  schema: public
+  schema: safetrust
 object_relationships:
   - name: conversation
     using:

--- a/metadata/tenants/safetrust/databases/tables/public_pricing_overrides.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_pricing_overrides.yaml
@@ -1,6 +1,6 @@
 table:
   name: pricing_overrides
-  schema: public
+  schema: safetrust
 
 object_relationships:
   - name: base_rule

--- a/metadata/tenants/safetrust/databases/tables/public_pricing_rules.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_pricing_rules.yaml
@@ -1,5 +1,5 @@
 table:
-  schema: public
+  schema: safetrust
   name: pricing_rules
 select_permissions:
   - role: anonymous

--- a/metadata/tenants/safetrust/databases/tables/public_reservations.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_reservations.yaml
@@ -1,23 +1,7 @@
-# NOTE: custom_name renames all generated GraphQL root fields.
-# Clients must update queries from 'reservations' to 'safetrust_reservations':
-#   reservations              → safetrust_reservations
-#   reservations_by_pk        → safetrust_reservations_by_pk
-#   insert_reservations_one   → insert_safetrust_reservations_one
-#   update_reservations       → update_safetrust_reservations
-#   delete_reservations       → delete_safetrust_reservations
 table:
   name: reservations
-  schema: public
+  schema: safetrust
 configuration:
-  # custom_name renames the GraphQL root fields for this table:
-  #   Query: reservations -> safetrust_reservations
-  #   Query (aggregate): reservations_aggregate -> safetrust_reservations_aggregate
-  #   Query (by PK): reservations_by_pk -> safetrust_reservations_by_pk
-  #   Mutation (insert): insert_reservations -> insert_safetrust_reservations
-  #   Mutation (update): update_reservations -> update_safetrust_reservations
-  #   Mutation (delete): delete_reservations -> delete_safetrust_reservations
-  # Client code querying "reservations" must update queries to use "safetrust_reservations"
-  custom_name: safetrust_reservations
   column_config:
     apartment_id:
       custom_name: apartmentId

--- a/metadata/tenants/safetrust/databases/tables/public_reservations.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_reservations.yaml
@@ -2,6 +2,7 @@ table:
   name: reservations
   schema: safetrust
 configuration:
+  custom_name: safetrust_reservations
   column_config:
     apartment_id:
       custom_name: apartmentId

--- a/metadata/tenants/safetrust/databases/tables/public_roles.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_roles.yaml
@@ -1,6 +1,6 @@
 table:
   name: roles
-  schema: public
+  schema: safetrust
 configuration:
   column_config: {}
   custom_column_names: {}
@@ -13,7 +13,7 @@ array_relationships:
         column: role_id
         table:
           name: user_roles
-          schema: public
+          schema: safetrust
 select_permissions:
   - role: admin
     permission:

--- a/metadata/tenants/safetrust/databases/tables/public_trustless_work_escrows.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_trustless_work_escrows.yaml
@@ -1,6 +1,6 @@
 table:
   name: trustless_work_escrows
-  schema: public
+  schema: safetrust
 configuration:
   column_config:
     id:
@@ -65,21 +65,21 @@ array_relationships:
         column: escrow_id
         table:
           name: escrow_milestones
-          schema: public
+          schema: safetrust
   - name: webhookEvents
     using:
       foreign_key_constraint_on:
         column: contract_id
         table:
           name: trustless_work_webhook_events
-          schema: public
+          schema: safetrust
   - name: pendingApprovals
     using:
       foreign_key_constraint_on:
         column: escrow_id
         table:
           name: escrow_pending_approvals
-          schema: public
+          schema: safetrust
 object_relationships:
   - name: apartment
     using:

--- a/metadata/tenants/safetrust/databases/tables/public_trustless_work_webhook_events.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_trustless_work_webhook_events.yaml
@@ -1,3 +1,3 @@
 table:
   name: trustless_work_webhook_events
-  schema: public
+  schema: safetrust

--- a/metadata/tenants/safetrust/databases/tables/public_user_roles.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_user_roles.yaml
@@ -1,6 +1,6 @@
 table:
   name: user_roles
-  schema: public
+  schema: safetrust
 configuration:
   column_config: {}
   custom_column_names: {}

--- a/metadata/tenants/safetrust/databases/tables/public_user_wallets.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_user_wallets.yaml
@@ -1,6 +1,6 @@
 table:
   name: user_wallets
-  schema: public
+  schema: safetrust
 object_relationships:
   - name: user
     using:

--- a/metadata/tenants/safetrust/databases/tables/public_users.yaml
+++ b/metadata/tenants/safetrust/databases/tables/public_users.yaml
@@ -1,6 +1,6 @@
 table:
   name: users
-  schema: public
+  schema: safetrust
 array_relationships:
   - name: user_roles
     using:
@@ -8,14 +8,14 @@ array_relationships:
         column: user_id
         table:
           name: user_roles
-          schema: public
+          schema: safetrust
   - name: user_wallets
     using:
       foreign_key_constraint_on:
         column: user_id
         table:
           name: user_wallets
-          schema: public
+          schema: safetrust
 select_permissions:
   - role: admin
     permission:

--- a/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/down.sql
+++ b/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/down.sql
@@ -28,5 +28,5 @@ ALTER FUNCTION IF EXISTS safetrust.get_apartments_in_bounds(double precision, do
 ALTER FUNCTION IF EXISTS safetrust.get_escrow_analytics_by_day(date, date) SET SCHEMA public;
 ALTER FUNCTION IF EXISTS safetrust.get_escrow_status_summary() SET SCHEMA public;
 
-ALTER DATABASE postgres RESET search_path;
+ALTER ROLE CURRENT_USER SET search_path TO public;
 DROP SCHEMA IF EXISTS safetrust;

--- a/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/down.sql
+++ b/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/down.sql
@@ -1,0 +1,32 @@
+-- Reverse: move all tables back to public
+ALTER TABLE safetrust.users                         SET SCHEMA public;
+ALTER TABLE safetrust.user_wallets                  SET SCHEMA public;
+ALTER TABLE safetrust.roles                         SET SCHEMA public;
+ALTER TABLE safetrust.user_roles                    SET SCHEMA public;
+ALTER TABLE safetrust.trustless_work_escrows        SET SCHEMA public;
+ALTER TABLE safetrust.trustless_work_webhook_events SET SCHEMA public;
+ALTER TABLE safetrust.escrow_milestones             SET SCHEMA public;
+ALTER TABLE safetrust.escrow_transactions           SET SCHEMA public;
+ALTER TABLE safetrust.apartments                    SET SCHEMA public;
+ALTER TABLE safetrust.apartment_images              SET SCHEMA public;
+ALTER TABLE safetrust.reservations                  SET SCHEMA public;
+ALTER TABLE safetrust.bid_requests                  SET SCHEMA public;
+ALTER TABLE safetrust.pricing_rules                 SET SCHEMA public;
+ALTER TABLE safetrust.pricing_overrides             SET SCHEMA public;
+ALTER TABLE safetrust.conversations                 SET SCHEMA public;
+ALTER TABLE safetrust.messages                      SET SCHEMA public;
+
+ALTER TABLE IF EXISTS safetrust.bid_status_histories         SET SCHEMA public;
+ALTER TABLE IF EXISTS safetrust.escrow_pending_approvals     SET SCHEMA public;
+ALTER TABLE IF EXISTS safetrust.escrow_analytics_by_day     SET SCHEMA public;
+ALTER TABLE IF EXISTS safetrust.escrow_status_summary        SET SCHEMA public;
+
+ALTER FUNCTION IF EXISTS safetrust.find_nearby_apartments(double precision, double precision, double precision) SET SCHEMA public;
+ALTER FUNCTION IF EXISTS safetrust.find_apartments_by_owner(uuid) SET SCHEMA public;
+ALTER FUNCTION IF EXISTS safetrust.search_apartments(text, text, numeric, numeric, text) SET SCHEMA public;
+ALTER FUNCTION IF EXISTS safetrust.get_apartments_in_bounds(double precision, double precision, double precision, double precision) SET SCHEMA public;
+ALTER FUNCTION IF EXISTS safetrust.get_escrow_analytics_by_day(date, date) SET SCHEMA public;
+ALTER FUNCTION IF EXISTS safetrust.get_escrow_status_summary() SET SCHEMA public;
+
+ALTER DATABASE postgres RESET search_path;
+DROP SCHEMA IF EXISTS safetrust;

--- a/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/up.sql
+++ b/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/up.sql
@@ -1,0 +1,49 @@
+-- Step 1: Create the safetrust schema
+CREATE SCHEMA IF NOT EXISTS safetrust;
+
+-- Step 2: Move all tables (preserves data, indexes, sequences)
+-- PostgreSQL ALTER TABLE ... SET SCHEMA is atomic and non-destructive
+ALTER TABLE public.users                         SET SCHEMA safetrust;
+ALTER TABLE public.user_wallets                  SET SCHEMA safetrust;
+ALTER TABLE public.roles                         SET SCHEMA safetrust;
+ALTER TABLE public.user_roles                    SET SCHEMA safetrust;
+ALTER TABLE public.trustless_work_escrows        SET SCHEMA safetrust;
+ALTER TABLE public.trustless_work_webhook_events SET SCHEMA safetrust;
+ALTER TABLE public.escrow_milestones             SET SCHEMA safetrust;
+ALTER TABLE public.escrow_transactions           SET SCHEMA safetrust;
+ALTER TABLE public.apartments                    SET SCHEMA safetrust;
+ALTER TABLE public.apartment_images              SET SCHEMA safetrust;
+ALTER TABLE public.reservations                  SET SCHEMA safetrust;
+ALTER TABLE public.bid_requests                  SET SCHEMA safetrust;
+ALTER TABLE public.pricing_rules                 SET SCHEMA safetrust;
+ALTER TABLE public.pricing_overrides             SET SCHEMA safetrust;
+ALTER TABLE public.conversations                 SET SCHEMA safetrust;
+ALTER TABLE public.messages                      SET SCHEMA safetrust;
+
+ALTER TABLE IF EXISTS public.bid_status_histories         SET SCHEMA safetrust;
+ALTER TABLE IF EXISTS public.escrow_pending_approvals     SET SCHEMA safetrust;
+ALTER TABLE IF EXISTS public.escrow_analytics_by_day     SET SCHEMA safetrust;
+ALTER TABLE IF EXISTS public.escrow_status_summary        SET SCHEMA safetrust;
+
+-- Move functions to safetrust schema if present
+ALTER FUNCTION IF EXISTS public.find_nearby_apartments(double precision, double precision, double precision) SET SCHEMA safetrust;
+ALTER FUNCTION IF EXISTS public.find_apartments_by_owner(uuid) SET SCHEMA safetrust;
+ALTER FUNCTION IF EXISTS public.search_apartments(text, text, numeric, numeric, text) SET SCHEMA safetrust;
+ALTER FUNCTION IF EXISTS public.get_apartments_in_bounds(double precision, double precision, double precision, double precision) SET SCHEMA safetrust;
+ALTER FUNCTION IF EXISTS public.get_escrow_analytics_by_day(date, date) SET SCHEMA safetrust;
+ALTER FUNCTION IF EXISTS public.get_escrow_status_summary() SET SCHEMA safetrust;
+
+-- Step 3: Add safetrust to search_path so existing queries still work
+-- during transition period (remove after all queries are updated)
+ALTER DATABASE postgres SET search_path TO safetrust, public;
+
+-- Step 4: Grant schema permissions to hasura role
+GRANT USAGE ON SCHEMA safetrust TO postgres;
+GRANT ALL ON ALL TABLES IN SCHEMA safetrust TO postgres;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA safetrust TO postgres;
+
+-- Step 5: Set default privileges for future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA safetrust
+  GRANT ALL ON TABLES TO postgres;
+ALTER DEFAULT PRIVILEGES IN SCHEMA safetrust
+  GRANT ALL ON SEQUENCES TO postgres;

--- a/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/up.sql
+++ b/migrations/safetrust/1779300000001_migrate_to_safetrust_schema/up.sql
@@ -35,7 +35,7 @@ ALTER FUNCTION IF EXISTS public.get_escrow_status_summary() SET SCHEMA safetrust
 
 -- Step 3: Add safetrust to search_path so existing queries still work
 -- during transition period (remove after all queries are updated)
-ALTER DATABASE postgres SET search_path TO safetrust, public;
+ALTER ROLE CURRENT_USER SET search_path TO safetrust, public;
 
 -- Step 4: Grant schema permissions to hasura role
 GRANT USAGE ON SCHEMA safetrust TO postgres;

--- a/migrations/safetrust/INIT.md
+++ b/migrations/safetrust/INIT.md
@@ -18,8 +18,10 @@ This migration moves them to the `safetrust` schema to:
 - GraphQL API surface is unchanged — field names are identical after Hasura
   re-tracks tables under the new schema
 
-## Applying this migration to an existing database
+## Deployment Sequence
 
+### 1. Apply Database Migration
+Apply the database schema migration using Hasura CLI:
 ```bash
 hasura migrate apply \
   --endpoint http://localhost:8080 \
@@ -28,3 +30,35 @@ hasura migrate apply \
   --version 1779300000001 \
   --type up
 ```
+
+### 2. Apply or Reload Hasura Metadata
+Apply or reload the corresponding Hasura metadata to update table tracking under the `safetrust` schema:
+```bash
+hasura metadata apply \
+  --endpoint http://localhost:8080 \
+  --admin-secret myadminsecretkey
+```
+
+### 3. GraphQL Smoke Test
+Run a GraphQL smoke test to verify queries and mutations are working as expected:
+```bash
+curl -X POST http://localhost:8080/v1/graphql \
+  -H "x-hasura-admin-secret: myadminsecretkey" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "query { safetrust_reservations(limit: 1) { id } }"}'
+```
+
+## Rollback Strategy
+
+In the event of a rollback:
+1. Revert the database migration:
+```bash
+hasura migrate apply \
+  --endpoint http://localhost:8080 \
+  --admin-secret myadminsecretkey \
+  --database-name safetrust \
+  --version 1779300000001 \
+  --type down
+```
+2. Restore and apply the previous Hasura metadata corresponding to the reverted schema.
+

--- a/migrations/safetrust/INIT.md
+++ b/migrations/safetrust/INIT.md
@@ -1,0 +1,30 @@
+# SafeTrust Schema Migration Strategy
+
+## Why this migration exists
+
+All SafeTrust tables were originally created in the PostgreSQL `public` schema.
+This migration moves them to the `safetrust` schema to:
+
+1. Enforce tenant data isolation at the schema permission level
+2. Eliminate GraphQL `custom_name` workarounds for collision avoidance
+3. Enable row-level security policies scoped to `safetrust.*`
+4. Allow `GRANT USAGE ON SCHEMA safetrust` for fine-grained access control
+
+## What was NOT changed
+
+- No existing migration files were modified
+- The migration sequence is preserved exactly
+- All data is preserved — `ALTER TABLE ... SET SCHEMA` is non-destructive
+- GraphQL API surface is unchanged — field names are identical after Hasura
+  re-tracks tables under the new schema
+
+## Applying this migration to an existing database
+
+```bash
+hasura migrate apply \
+  --endpoint http://localhost:8080 \
+  --admin-secret myadminsecretkey \
+  --database-name safetrust \
+  --version 1779300000001 \
+  --type up
+```

--- a/seeds/safetrust/1733963959819_user_seed.sql
+++ b/seeds/safetrust/1733963959819_user_seed.sql
@@ -2,7 +2,7 @@
 -- id must be TEXT (Firebase UID format), not UUID
 -- On conflict: skip — safe for repeated seed apply runs
 
-INSERT INTO public.users (
+INSERT INTO safetrust.users (
     id,
     firebase_uid,
     email,

--- a/seeds/safetrust/1733970410880_apartments_seed.sql
+++ b/seeds/safetrust/1733970410880_apartments_seed.sql
@@ -3,14 +3,14 @@
 -- Owner lookup uses firebase_uid for stable cross-seed references
 
 -- Idempotency: remove demo apartments before reinserting
-DELETE FROM public.apartments
+DELETE FROM safetrust.apartments
 WHERE owner_id IN (
-    SELECT id FROM public.users
+    SELECT id FROM safetrust.users
     WHERE firebase_uid IN ('demo-tenant-uid-001', 'demo-owner-uid-002')
 );
 
 -- Apartment 1
-INSERT INTO public.apartments (
+INSERT INTO safetrust.apartments (
     id,
     owner_id,
     name,
@@ -35,11 +35,11 @@ SELECT
     true,
     NOW() - INTERVAL '2 months',
     NOW() + INTERVAL '10 months'
-FROM public.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
 ON CONFLICT (id) DO NOTHING;
 
 -- Apartment 2
-INSERT INTO public.apartments (
+INSERT INTO safetrust.apartments (
     id,
     owner_id,
     name,
@@ -64,5 +64,5 @@ SELECT
     true,
     NOW() - INTERVAL '1 month',
     NOW() + INTERVAL '12 months'
-FROM public.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
 ON CONFLICT (id) DO NOTHING;

--- a/seeds/safetrust/1733970410880_apartments_seed.sql
+++ b/seeds/safetrust/1733970410880_apartments_seed.sql
@@ -3,32 +3,32 @@
 -- Owner lookup uses firebase_uid for stable cross-seed references
 
 -- Idempotency: remove child records and demo apartments before reinserting
-DELETE FROM public.apartment_images
+DELETE FROM safetrust.apartment_images
 WHERE apartment_id IN (
-    SELECT id FROM public.apartments
+    SELECT id FROM safetrust.apartments
     WHERE owner_id IN (
-        SELECT id FROM public.users
+        SELECT id FROM safetrust.users
         WHERE firebase_uid IN ('demo-tenant-uid-001', 'demo-owner-uid-002')
     )
 );
 
-DELETE FROM public.reservations
+DELETE FROM safetrust.reservations
 WHERE apartment_id IN (
-    SELECT id FROM public.apartments
+    SELECT id FROM safetrust.apartments
     WHERE owner_id IN (
-        SELECT id FROM public.users
+        SELECT id FROM safetrust.users
         WHERE firebase_uid IN ('demo-tenant-uid-001', 'demo-owner-uid-002')
     )
 );
 
-DELETE FROM public.apartments
+DELETE FROM safetrust.apartments
 WHERE owner_id IN (
-    SELECT id FROM public.users
+    SELECT id FROM safetrust.users
     WHERE firebase_uid IN ('demo-tenant-uid-001', 'demo-owner-uid-002')
 );
 
 -- Apartment 1
-INSERT INTO public.apartments (
+INSERT INTO safetrust.apartments (
     id,
     owner_id,
     name,
@@ -53,11 +53,11 @@ SELECT
     true,
     NOW() - INTERVAL '2 months',
     NOW() + INTERVAL '10 months'
-FROM public.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
 ON CONFLICT (id) DO NOTHING;
 
 -- Apartment 2
-INSERT INTO public.apartments (
+INSERT INTO safetrust.apartments (
     id,
     owner_id,
     name,
@@ -82,5 +82,5 @@ SELECT
     true,
     NOW() - INTERVAL '1 month',
     NOW() + INTERVAL '12 months'
-FROM public.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-owner-uid-002'
 ON CONFLICT (id) DO NOTHING;

--- a/seeds/safetrust/1734151104298_escrow_transactions.sql
+++ b/seeds/safetrust/1734151104298_escrow_transactions.sql
@@ -1,10 +1,10 @@
 -- Seed for escrow_transactions table
--- Using public.escrow_transactions (canonical escrow table)
+-- Using safetrust.escrow_transactions (canonical escrow table)
 
 -- Clear existing seed data (development only)
-TRUNCATE public.escrow_transactions RESTART IDENTITY CASCADE;
+TRUNCATE safetrust.escrow_transactions RESTART IDENTITY CASCADE;
 
-INSERT INTO public.escrow_transactions (
+INSERT INTO safetrust.escrow_transactions (
     id,
     contract_id,
     engagement_id,

--- a/seeds/safetrust/1734473134980_apartment_images_seed.sql
+++ b/seeds/safetrust/1734473134980_apartment_images_seed.sql
@@ -6,14 +6,14 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Idempotency: clear existing demo images before re-inserting
-DELETE FROM public.apartment_images
+DELETE FROM safetrust.apartment_images
 WHERE apartment_id IN (
     '550e8400-e29b-41d4-a716-446655440001'::uuid,
     '550e8400-e29b-41d4-a716-446655440002'::uuid
 );
 
 -- Images for Apartment 1: 'Moderno Apartamento en San José Centro'
-INSERT INTO apartment_images (id, apartment_id, image_url, uploaded_at)
+INSERT INTO safetrust.apartment_images (id, apartment_id, image_url, uploaded_at)
 VALUES
     (uuid_generate_v4(), '550e8400-e29b-41d4-a716-446655440001',
      'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-1.jpg', NOW()),
@@ -23,7 +23,7 @@ VALUES
      'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-9-810x531.jpg', NOW());
 
 -- Images for Apartment 2: 'Suite Ejecutiva Sabana Norte'
-INSERT INTO apartment_images (id, apartment_id, image_url, uploaded_at)
+INSERT INTO safetrust.apartment_images (id, apartment_id, image_url, uploaded_at)
 VALUES
     (uuid_generate_v4(), '550e8400-e29b-41d4-a716-446655440002',
      'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-22-810x540.jpg', NOW()),

--- a/seeds/safetrust/1734473134980_apartment_images_seed.sql
+++ b/seeds/safetrust/1734473134980_apartment_images_seed.sql
@@ -6,14 +6,14 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Idempotency: clear existing demo images before re-inserting
-DELETE FROM public.apartment_images
+DELETE FROM safetrust.apartment_images
 WHERE apartment_id IN (
     '550e8400-e29b-41d4-a716-446655440001'::uuid,
     '550e8400-e29b-41d4-a716-446655440002'::uuid
 );
 
 -- Images for Apartment 1: 'Moderno Apartamento en San José Centro'
-INSERT INTO apartment_images (id, apartment_id, image_url, uploaded_at)
+INSERT INTO safetrust.apartment_images (id, apartment_id, image_url, uploaded_at)
 VALUES
     (uuid_generate_v4(), '550e8400-e29b-41d4-a716-446655440001',
      'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-1.jpg', NOW()),
@@ -24,7 +24,7 @@ VALUES
 ON CONFLICT DO NOTHING;
 
 -- Images for Apartment 2: 'Suite Ejecutiva Sabana Norte'
-INSERT INTO apartment_images (id, apartment_id, image_url, uploaded_at)
+INSERT INTO safetrust.apartment_images (id, apartment_id, image_url, uploaded_at)
 VALUES
     (uuid_generate_v4(), '550e8400-e29b-41d4-a716-446655440002',
      'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-22-810x540.jpg', NOW()),

--- a/seeds/safetrust/1734710839892_bid_requests_seed.sql
+++ b/seeds/safetrust/1734710839892_bid_requests_seed.sql
@@ -3,14 +3,14 @@
 -- Depends on: 1733963959819_user_seed.sql (canonical: 01_users_seed.sql), 1733970410880_departments_seed.sql (canonical: 02_apartments_seed.sql) — must run after both
 
 -- Idempotency: remove demo bid requests before reinserting
-DELETE FROM public.bid_requests
+DELETE FROM safetrust.bid_requests
 WHERE tenant_id IN (
-    SELECT id FROM public.users
+    SELECT id FROM safetrust.users
     WHERE firebase_uid = 'demo-tenant-uid-001'
 );
 
 -- Bid Request 1: PENDING on Apartment 1
-INSERT INTO public.bid_requests (
+INSERT INTO safetrust.bid_requests (
     id,
     apartment_id,
     tenant_id,
@@ -25,11 +25,11 @@ SELECT
     'PENDING',
     1150.00,
     NOW() + INTERVAL '1 month'
-FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
 ON CONFLICT (id) DO NOTHING;
 
 -- Bid Request 2: CANCELLED on Apartment 2
-INSERT INTO public.bid_requests (
+INSERT INTO safetrust.bid_requests (
     id,
     apartment_id,
     tenant_id,
@@ -44,5 +44,5 @@ SELECT
     'CANCELLED',
     900.00,
     NOW() + INTERVAL '2 months'
-FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
 ON CONFLICT (id) DO NOTHING;

--- a/seeds/safetrust/1735509833667_create_bid_status_histories.sql
+++ b/seeds/safetrust/1735509833667_create_bid_status_histories.sql
@@ -2,14 +2,14 @@
 -- Depends on: 1734710839892_bid_requests_seed.sql (must run after bid_requests)
 
 -- Idempotency: remove demo bid status histories before reinserting
-DELETE FROM public.bid_status_histories
+DELETE FROM safetrust.bid_status_histories
 WHERE bid_request_id IN (
     '660e8400-e29b-41d4-a716-446655440001'::uuid,
     '660e8400-e29b-41d4-a716-446655440002'::uuid
 );
 
 -- Status history for Bid Request 1 (PENDING on Apartment 1)
-INSERT INTO public.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
+INSERT INTO safetrust.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
 SELECT
     '770e8400-e29b-41d4-a716-446655440001'::uuid,
     '660e8400-e29b-41d4-a716-446655440001'::uuid,
@@ -17,11 +17,11 @@ SELECT
     'Bid request has been submitted.',
     u.id,
     NOW()
-FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
 ON CONFLICT (id) DO NOTHING;
 
 -- Status history for Bid Request 2 (CANCELLED on Apartment 2) — entry 1: Submitted
-INSERT INTO public.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
+INSERT INTO safetrust.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
 SELECT
     '770e8400-e29b-41d4-a716-446655440002'::uuid,
     '660e8400-e29b-41d4-a716-446655440002'::uuid,
@@ -29,11 +29,11 @@ SELECT
     'Bid request has been submitted.',
     u.id,
     NOW() - INTERVAL '1 day'
-FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
 ON CONFLICT (id) DO NOTHING;
 
 -- Status history for Bid Request 2 (CANCELLED on Apartment 2) — entry 2: Cancelled
-INSERT INTO public.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
+INSERT INTO safetrust.bid_status_histories (id, bid_request_id, status, notes, changed_by, created_at)
 SELECT
     '770e8400-e29b-41d4-a716-446655440003'::uuid,
     '660e8400-e29b-41d4-a716-446655440002'::uuid,
@@ -41,5 +41,5 @@ SELECT
     'Bid request cancelled by tenant.',
     u.id,
     NOW()
-FROM public.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
+FROM safetrust.users u WHERE u.firebase_uid = 'demo-tenant-uid-001'
 ON CONFLICT (id) DO NOTHING;

--- a/seeds/safetrust/1776200000000_trustless_work_escrows_seed.sql
+++ b/seeds/safetrust/1776200000000_trustless_work_escrows_seed.sql
@@ -2,21 +2,21 @@
 -- Uses contract IDs matching _trustless_work_webhook_events.sql
 -- Safe to re-run: DELETE guards on all inserts
 
-DELETE FROM public.escrow_milestones
+DELETE FROM safetrust.escrow_milestones
   WHERE escrow_id IN (
-    SELECT id FROM public.trustless_work_escrows
+    SELECT id FROM safetrust.trustless_work_escrows
     WHERE contract_id IN (
       'CAATN5DTEST00001','CAATN5DTEST00002','CAATN5DTEST00003'
     )
   );
 
-DELETE FROM public.trustless_work_escrows
+DELETE FROM safetrust.trustless_work_escrows
   WHERE contract_id IN (
     'CAATN5DTEST00001','CAATN5DTEST00002','CAATN5DTEST00003'
   );
 
 -- Contract 1: milestone_approved (matches escrow.created + milestone.approved events)
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id, marker, approver, releaser,
   escrow_type, status, asset_code, amount, balance, tenant_id
 ) VALUES (
@@ -29,7 +29,7 @@ INSERT INTO public.trustless_work_escrows (
 );
 
 -- Contract 2: funded (matches escrow.funded event)
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id, marker, approver, releaser,
   escrow_type, status, asset_code, amount, balance, tenant_id
 ) VALUES (
@@ -42,7 +42,7 @@ INSERT INTO public.trustless_work_escrows (
 );
 
 -- Contract 3: completed (matches escrow.completed + escrow.cancelled events)
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id, marker, approver, releaser,
   escrow_type, status, asset_code, amount, balance, tenant_id
 ) VALUES (
@@ -55,7 +55,7 @@ INSERT INTO public.trustless_work_escrows (
 );
 
 -- Milestone for CAATN5DTEST00001 (status: milestone_approved)
-INSERT INTO public.escrow_milestones (
+INSERT INTO safetrust.escrow_milestones (
   escrow_id, milestone_id, description,
   amount, status, approved_by, approved_at, tenant_id
 )
@@ -66,6 +66,6 @@ SELECT
   'GAWVVSATEST0001APPROVER',
   NOW() - INTERVAL '2 days',
   'safetrust'
-FROM public.trustless_work_escrows
+FROM safetrust.trustless_work_escrows
 WHERE contract_id = 'CAATN5DTEST00001'
 ON CONFLICT (escrow_id, milestone_id) DO NOTHING;

--- a/seeds/safetrust/1778100000000_conversations_seed.sql
+++ b/seeds/safetrust/1778100000000_conversations_seed.sql
@@ -4,10 +4,10 @@
 -- Idempotent: delete the demo threads before inserting them again.
 -- ============================================================================
 
-DELETE FROM public.messages
+DELETE FROM safetrust.messages
 WHERE conversation_id IN (
   SELECT id
-  FROM public.conversations
+  FROM safetrust.conversations
   WHERE tenant_id = 'safetrust'
     AND apartment_id IN (
       '550e8400-e29b-41d4-a716-446655440001'::uuid,
@@ -19,7 +19,7 @@ WHERE conversation_id IN (
     )
 );
 
-DELETE FROM public.conversations
+DELETE FROM safetrust.conversations
 WHERE tenant_id = 'safetrust'
   AND apartment_id IN (
     '550e8400-e29b-41d4-a716-446655440001'::uuid,
@@ -31,7 +31,7 @@ WHERE tenant_id = 'safetrust'
   );
 
 -- Conversation 1: pre-booking inquiry (no escrow yet).
-INSERT INTO public.conversations (
+INSERT INTO safetrust.conversations (
   id,
   apartment_id,
   host_id,
@@ -48,7 +48,7 @@ INSERT INTO public.conversations (
 )
 ON CONFLICT DO NOTHING;
 
-INSERT INTO public.messages (
+INSERT INTO safetrust.messages (
   conversation_id,
   sender_id,
   body,
@@ -82,7 +82,7 @@ INSERT INTO public.messages (
   );
 
 -- Conversation 2: active booking with escrow lifecycle messages.
-INSERT INTO public.conversations (
+INSERT INTO safetrust.conversations (
   id,
   apartment_id,
   host_id,
@@ -99,11 +99,11 @@ SELECT
   twe.id,
   'active',
   'safetrust'
-FROM public.trustless_work_escrows AS twe
+FROM safetrust.trustless_work_escrows AS twe
 WHERE twe.contract_id = 'CAATN5DTEST00002'
   AND twe.tenant_id = 'safetrust';
 
-INSERT INTO public.messages (
+INSERT INTO safetrust.messages (
   conversation_id,
   sender_id,
   body,

--- a/seeds/safetrust/1778100000000_conversations_seed.sql
+++ b/seeds/safetrust/1778100000000_conversations_seed.sql
@@ -4,10 +4,10 @@
 -- Idempotent: delete the demo threads before inserting them again.
 -- ============================================================================
 
-DELETE FROM public.messages
+DELETE FROM safetrust.messages
 WHERE conversation_id IN (
   SELECT id
-  FROM public.conversations
+  FROM safetrust.conversations
   WHERE tenant_id = 'safetrust'
     AND apartment_id IN (
       '550e8400-e29b-41d4-a716-446655440001'::uuid,
@@ -19,7 +19,7 @@ WHERE conversation_id IN (
     )
 );
 
-DELETE FROM public.conversations
+DELETE FROM safetrust.conversations
 WHERE tenant_id = 'safetrust'
   AND apartment_id IN (
     '550e8400-e29b-41d4-a716-446655440001'::uuid,
@@ -31,7 +31,7 @@ WHERE tenant_id = 'safetrust'
   );
 
 -- Conversation 1: pre-booking inquiry (no escrow yet).
-INSERT INTO public.conversations (
+INSERT INTO safetrust.conversations (
   id,
   apartment_id,
   host_id,
@@ -47,7 +47,7 @@ INSERT INTO public.conversations (
   'safetrust'
 );
 
-INSERT INTO public.messages (
+INSERT INTO safetrust.messages (
   conversation_id,
   sender_id,
   body,
@@ -81,7 +81,7 @@ INSERT INTO public.messages (
   );
 
 -- Conversation 2: active booking with escrow lifecycle messages.
-INSERT INTO public.conversations (
+INSERT INTO safetrust.conversations (
   id,
   apartment_id,
   host_id,
@@ -98,11 +98,11 @@ SELECT
   twe.id,
   'active',
   'safetrust'
-FROM public.trustless_work_escrows AS twe
+FROM safetrust.trustless_work_escrows AS twe
 WHERE twe.contract_id = 'CAATN5DTEST00002'
   AND twe.tenant_id = 'safetrust';
 
-INSERT INTO public.messages (
+INSERT INTO safetrust.messages (
   conversation_id,
   sender_id,
   body,

--- a/seeds/safetrust/1778200000000_reservations_seed.sql
+++ b/seeds/safetrust/1778200000000_reservations_seed.sql
@@ -1,11 +1,11 @@
 -- seeds/safetrust/1778200000000_reservations_seed.sql
--- Seed for public.reservations table
+-- Seed for safetrust.reservations table
 -- Covers all valid lifecycle statuses defined by valid_reservation_status CHECK constraint
 -- Depends on: users seed, apartments seed, trustless_work_escrows seed (3 contracts available)
 -- Note: each escrow_id must be unique — one escrow per reservation
 -- Note: dates must not overlap per apartment — enforced by no_overlapping_reservations constraint
 
-DELETE FROM public.reservations
+DELETE FROM safetrust.reservations
 WHERE guest_id IN (
   'demo-tenant-uid-001',
   'demo-owner-uid-002',
@@ -18,7 +18,7 @@ WHERE guest_id IN (
 );
 
 -- 1. status: pending — apt 1, far future, no escrow yet
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -33,7 +33,7 @@ INSERT INTO public.reservations (
 );
 
 -- 2. status: escrow_created — apt 2, far future, links to CAATN5DTEST00001
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -41,14 +41,14 @@ INSERT INTO public.reservations (
   gen_random_uuid(),
   '550e8400-e29b-41d4-a716-446655440002'::uuid,
   'demo-user-uid-003',
-  (SELECT id FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00001'),
+  (SELECT id FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00001'),
   NOW() + INTERVAL '70 days',
   NOW() + INTERVAL '77 days',
   1800.00, 'USDC', 'escrow_created', 'safetrust'
 );
 
 -- 3. status: funded — apt 1, near future, links to CAATN5DTEST00002
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -56,14 +56,14 @@ INSERT INTO public.reservations (
   gen_random_uuid(),
   '550e8400-e29b-41d4-a716-446655440001'::uuid,
   'demo-user-uid-004',
-  (SELECT id FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00002'),
+  (SELECT id FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00002'),
   NOW() + INTERVAL '10 days',
   NOW() + INTERVAL '17 days',
   3200.00, 'USDC', 'funded', 'safetrust'
 );
 
 -- 4. status: checked_in — apt 2, current stay, links to CAATN5DTEST00003
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -71,14 +71,14 @@ INSERT INTO public.reservations (
   gen_random_uuid(),
   '550e8400-e29b-41d4-a716-446655440002'::uuid,
   'demo-user-uid-005',
-  (SELECT id FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00003'),
+  (SELECT id FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00003'),
   NOW() - INTERVAL '2 days',
   NOW() + INTERVAL '5 days',
   2100.00, 'USDC', 'checked_in', 'safetrust'
 );
 
 -- 5. status: completed — apt 1, past stay, no escrow link needed
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -93,7 +93,7 @@ INSERT INTO public.reservations (
 );
 
 -- 6. status: disputed — apt 2, past stay, no escrow link needed
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -108,7 +108,7 @@ INSERT INTO public.reservations (
 );
 
 -- 7. status: resolved — apt 1, older past stay, no escrow link needed
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id
@@ -124,7 +124,7 @@ INSERT INTO public.reservations (
 
 -- 8. status: cancelled — apt 2, future dates, no escrow needed
 -- cancelled status is excluded from the overlap constraint
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id, escrow_id,
   check_in_date, check_out_date,
   total_amount, asset_code, status, tenant_id

--- a/seeds/safetrust/_trustless_work_webhook_events.sql
+++ b/seeds/safetrust/_trustless_work_webhook_events.sql
@@ -3,9 +3,9 @@
 -- contract_id values use CAATN5DTEST... prefix for test data
 
 -- Idempotency: clear existing webhook events
-TRUNCATE public.trustless_work_webhook_events CASCADE;
+TRUNCATE safetrust.trustless_work_webhook_events CASCADE;
 
-INSERT INTO public.trustless_work_webhook_events (
+INSERT INTO safetrust.trustless_work_webhook_events (
   contract_id, event_type, payload, signature,
   processed, processed_at, error_message,
   retry_count, max_retries, next_retry_at, tenant_id

--- a/tests/karate/features/auth/roles.feature
+++ b/tests/karate/features/auth/roles.feature
@@ -10,16 +10,16 @@ Feature: GET /api/auth/me — role-based redirect behavior
     * def adminToken = karate.call('classpath:helpers/get-firebase-token.js', { uid: adminUid })
 
     # Clean and seed users
-    * db.execute("DELETE FROM public.user_roles WHERE user_id IN ('host-user-001','guest-user-001','admin-user-001')")
-    * db.execute("DELETE FROM public.users WHERE id IN ('host-user-001','guest-user-001','admin-user-001')")
-    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('host-user-001',  'host-user-001',  'host@safetrust.cr')  ON CONFLICT DO NOTHING")
-    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('guest-user-001', 'guest-user-001', 'guest@safetrust.cr') ON CONFLICT DO NOTHING")
-    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('admin-user-001', 'admin-user-001', 'admin@safetrust.cr') ON CONFLICT DO NOTHING")
+    * db.execute("DELETE FROM safetrust.user_roles WHERE user_id IN ('host-user-001','guest-user-001','admin-user-001')")
+    * db.execute("DELETE FROM safetrust.users WHERE id IN ('host-user-001','guest-user-001','admin-user-001')")
+    * db.execute("INSERT INTO safetrust.users (id, firebase_uid, email) VALUES ('host-user-001',  'host-user-001',  'host@safetrust.cr')  ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO safetrust.users (id, firebase_uid, email) VALUES ('guest-user-001', 'guest-user-001', 'guest@safetrust.cr') ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO safetrust.users (id, firebase_uid, email) VALUES ('admin-user-001', 'admin-user-001', 'admin@safetrust.cr') ON CONFLICT DO NOTHING")
 
     # Assign roles
-    * db.execute("INSERT INTO public.user_roles (user_id, role_id) SELECT 'host-user-001',  id FROM public.roles WHERE name = 'host'  ON CONFLICT DO NOTHING")
-    * db.execute("INSERT INTO public.user_roles (user_id, role_id) SELECT 'guest-user-001', id FROM public.roles WHERE name = 'guest' ON CONFLICT DO NOTHING")
-    * db.execute("INSERT INTO public.user_roles (user_id, role_id) SELECT 'admin-user-001', id FROM public.roles WHERE name = 'admin' ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO safetrust.user_roles (user_id, role_id) SELECT 'host-user-001',  id FROM safetrust.roles WHERE name = 'host'  ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO safetrust.user_roles (user_id, role_id) SELECT 'guest-user-001', id FROM safetrust.roles WHERE name = 'guest' ON CONFLICT DO NOTHING")
+    * db.execute("INSERT INTO safetrust.user_roles (user_id, role_id) SELECT 'admin-user-001', id FROM safetrust.roles WHERE name = 'admin' ON CONFLICT DO NOTHING")
 
   # ── Host ──
 
@@ -33,7 +33,7 @@ Feature: GET /api/auth/me — role-based redirect behavior
     And match response.redirect == '/dashboard/escrow-dashboard'
 
   Scenario: Host role is stored correctly in user_roles table
-    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'host-user-001' ORDER BY r.name")
+    * def rows = db.query("SELECT r.name FROM safetrust.roles r JOIN safetrust.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'host-user-001' ORDER BY r.name")
     Then match rows == [{ name: 'host' }]
 
   # ── Guest ─
@@ -48,7 +48,7 @@ Feature: GET /api/auth/me — role-based redirect behavior
     And match response.redirect == '/dashboard/guest'
 
   Scenario: Guest role is stored correctly in user_roles table
-    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'guest-user-001' ORDER BY r.name")
+    * def rows = db.query("SELECT r.name FROM safetrust.roles r JOIN safetrust.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'guest-user-001' ORDER BY r.name")
     Then match rows == [{ name: 'guest' }]
 
   # ── Admin ─
@@ -63,7 +63,7 @@ Feature: GET /api/auth/me — role-based redirect behavior
     And match response.redirect == '/dashboard/escrow-dashboard'
 
   Scenario: Admin role is stored correctly in user_roles table
-    * def rows = db.query("SELECT r.name FROM public.roles r JOIN public.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'admin-user-001' ORDER BY r.name")
+    * def rows = db.query("SELECT r.name FROM safetrust.roles r JOIN safetrust.user_roles ur ON ur.role_id = r.id WHERE ur.user_id = 'admin-user-001' ORDER BY r.name")
     Then match rows == [{ name: 'admin' }]
 
   # ── No role ─
@@ -71,8 +71,8 @@ Feature: GET /api/auth/me — role-based redirect behavior
   Scenario: User with no role assigned defaults to guest redirect
     * def noRoleUid = 'no-role-user-001'
     * def noRoleToken = karate.call('classpath:helpers/get-firebase-token.js', { uid: noRoleUid })
-    * db.execute("DELETE FROM public.users WHERE id = 'no-role-user-001'")
-    * db.execute("INSERT INTO public.users (id, firebase_uid, email) VALUES ('no-role-user-001', 'no-role-user-001', 'norole@safetrust.cr') ON CONFLICT DO NOTHING")
+    * db.execute("DELETE FROM safetrust.users WHERE id = 'no-role-user-001'")
+    * db.execute("INSERT INTO safetrust.users (id, firebase_uid, email) VALUES ('no-role-user-001', 'no-role-user-001', 'norole@safetrust.cr') ON CONFLICT DO NOTHING")
     Given path '/api/auth/me'
     And header Authorization = 'Bearer ' + noRoleToken
     And header x-test-uid = noRoleUid

--- a/tests/karate/features/auth/sync-wallet.feature
+++ b/tests/karate/features/auth/sync-wallet.feature
@@ -10,7 +10,7 @@ Feature: POST /api/auth/sync-wallet
     # validation performed by the Rust stellar-utils addon.
     * def stellarAddress = 'GDVEU3DD4KOFECV66VIHWEZOYX4ZKR3WV27L464SIIPOU2IUI3JCZA57'
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-users.sql'))
-    * db.execute("DELETE FROM public.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
+    * db.execute("DELETE FROM safetrust.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
 
   Scenario: Insert new Stellar wallet → 200 with success and wallet_address
     Given path '/api/auth/sync-wallet'
@@ -21,14 +21,14 @@ Feature: POST /api/auth/sync-wallet
     Then status 200
     And match response.success == true
     And match response.wallet_address == stellarAddress
-    * def rows = db.query("SELECT * FROM public.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
+    * def rows = db.query("SELECT * FROM safetrust.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
     And match rows[0].user_id == testUid
     And match rows[0].chain_type == 'STELLAR'
     And match rows[0].is_primary == '#? _ == "true" || _ == "t" || _ == true'
 
   Scenario: Upsert same address updates user_id and is_primary
     # Pre-seed the address under tenant-456, then reassign it to testUid via the endpoint
-    * db.execute("INSERT INTO public.user_wallets (user_id, wallet_address, chain_type, is_primary) VALUES ('tenant-456', '" + stellarAddress + "', 'STELLAR', false)")
+    * db.execute("INSERT INTO safetrust.user_wallets (user_id, wallet_address, chain_type, is_primary) VALUES ('tenant-456', '" + stellarAddress + "', 'STELLAR', false)")
     Given path '/api/auth/sync-wallet'
     And header Authorization = 'Bearer ' + validToken
     And header x-test-uid = testUid
@@ -36,7 +36,7 @@ Feature: POST /api/auth/sync-wallet
     When method POST
     Then status 200
     And match response.success == true
-    * def rows = db.query("SELECT * FROM public.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
+    * def rows = db.query("SELECT * FROM safetrust.user_wallets WHERE wallet_address = '" + stellarAddress + "'")
     And match rows[0].user_id == testUid
 
   Scenario: Missing wallet_address → 400

--- a/tests/karate/features/escrows/approve-milestone.feature
+++ b/tests/karate/features/escrows/approve-milestone.feature
@@ -5,7 +5,7 @@ Feature: POST /api/escrows/approve-milestone — TrustlessWork milestone approva
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-users.sql'))
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-escrows.sql'))
     # Reset milestone state before each scenario
-    * db.execute("UPDATE public.escrow_milestones SET status = 'pending', approved_by = NULL, approved_at = NULL WHERE milestone_id = 'check_in'")
+    * db.execute("UPDATE safetrust.escrow_milestones SET status = 'pending', approved_by = NULL, approved_at = NULL WHERE milestone_id = 'check_in'")
 
   Scenario: Valid approval callback updates milestone to approved and escrow to milestone_approved
     * def body = { "contractId": "escrow-funded-001", "milestoneId": "check_in", "approver": "GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z", "flag": true }
@@ -17,10 +17,10 @@ Feature: POST /api/escrows/approve-milestone — TrustlessWork milestone approva
     When method POST
     Then status 200
     And match response.received == true
-    * def milestone = db.query("SELECT status, approved_by FROM public.escrow_milestones WHERE milestone_id = 'check_in'")
+    * def milestone = db.query("SELECT status, approved_by FROM safetrust.escrow_milestones WHERE milestone_id = 'check_in'")
     And match milestone[0].status == 'approved'
     And match milestone[0].approved_by == 'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z'
-    * def escrow = db.query("SELECT status FROM public.trustless_work_escrows WHERE contract_id = 'escrow-funded-001'")
+    * def escrow = db.query("SELECT status FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-funded-001'")
     And match escrow[0].status == 'milestone_approved'
 
   Scenario: Missing contractId returns 400

--- a/tests/karate/features/escrows/dispute.feature
+++ b/tests/karate/features/escrows/dispute.feature
@@ -15,7 +15,7 @@ Feature: POST /api/escrows/dispute — TrustlessWork dispute callback
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status FROM public.trustless_work_escrows WHERE contract_id = 'escrow-funded-001'")
+    * def rows = db.query("SELECT status FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-funded-001'")
     And match rows[0].status == 'disputed'
 
   Scenario: Missing contractId returns 400

--- a/tests/karate/features/escrows/escrow-lifecycle.feature
+++ b/tests/karate/features/escrows/escrow-lifecycle.feature
@@ -46,8 +46,8 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     function() {
       var ids = "('LIFECYCLE_TEST_CONTRACT_001','DISPUTE_TEST_CONTRACT_001','TIMING_TEST_001')";
       // Cascades escrow_milestones; also drop webhook idempotency rows for these contracts.
-      db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id IN " + ids);
-      db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id IN " + ids);
+      db.execute("DELETE FROM safetrust.trustless_work_webhook_events WHERE contract_id IN " + ids);
+      db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE contract_id IN " + ids);
     }
     """
     # Failure-safe: remove this feature's fixtures even if a later scenario fails.
@@ -78,7 +78,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero, amount FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero, amount FROM safetrust.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match rows[0].status == 'created'
     And match rows[0].balance_is_zero == '1'
     And match rows[0].amount == '1200.0000000'
@@ -94,7 +94,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def rows = db.query("SELECT status, balance FROM safetrust.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match rows[0].status == 'funded'
     And match rows[0].balance == '1200.0000000'
 
@@ -104,7 +104,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     # before the Hasura status filter runs. A second identical fund callback would
     # return 200 { received: true } without testing the status guard. Clear the
     # processed escrow.funded event so this request exercises the mutation path.
-    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = '" + lifecycleContractId + "' AND event_type = 'escrow.funded'")
+    * db.execute("DELETE FROM safetrust.trustless_work_webhook_events WHERE contract_id = '" + lifecycleContractId + "' AND event_type = 'escrow.funded'")
     * def body = { "contractId": "#(lifecycleContractId)", "signer": "#(approver)", "amount": 1200.00 }
     * def bodyStr = JSON.stringify(body)
     Given path '/api/escrows/fund'
@@ -116,14 +116,14 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     Then status 404
     And match response.error contains 'Escrow not found'
     # Guard must not mutate funded state / balance
-    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def rows = db.query("SELECT status, balance FROM safetrust.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match rows[0].status == 'funded'
     And match rows[0].balance == '1200.0000000'
 
   # ── Step 3: Approve milestone — O(2) DB writes: milestone + escrow ────────
   Scenario: Step 3 — approve-milestone updates milestone and advances escrow to milestone_approved
-    * def milestoneEscrowId = db.query("SELECT id FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")[0].id
-    * db.execute("INSERT INTO public.escrow_milestones (escrow_id, milestone_id, description, amount, status, tenant_id) VALUES ('" + milestoneEscrowId + "', 'check_in', 'Test milestone', 1200.0, 'pending', 'safetrust') ON CONFLICT (escrow_id, milestone_id) DO NOTHING")
+    * def milestoneEscrowId = db.query("SELECT id FROM safetrust.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")[0].id
+    * db.execute("INSERT INTO safetrust.escrow_milestones (escrow_id, milestone_id, description, amount, status, tenant_id) VALUES ('" + milestoneEscrowId + "', 'check_in', 'Test milestone', 1200.0, 'pending', 'safetrust') ON CONFLICT (escrow_id, milestone_id) DO NOTHING")
     * def body =
     """
     {
@@ -141,10 +141,10 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     When method POST
     Then status 200
     And match response.received == true
-    * def milestone = db.query("SELECT status, approved_by FROM public.escrow_milestones WHERE milestone_id = 'check_in' AND escrow_id = '" + milestoneEscrowId + "'")
+    * def milestone = db.query("SELECT status, approved_by FROM safetrust.escrow_milestones WHERE milestone_id = 'check_in' AND escrow_id = '" + milestoneEscrowId + "'")
     And match milestone[0].status == 'approved'
     And match milestone[0].approved_by == approver
-    * def escrow = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def escrow = db.query("SELECT status, balance FROM safetrust.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match escrow[0].status == 'milestone_approved'
     # Approval must not zero / alter funded balance
     And match escrow[0].balance == '1200.0000000'
@@ -160,12 +160,12 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM safetrust.trustless_work_escrows WHERE contract_id = '" + lifecycleContractId + "'")
     And match rows[0].status == 'completed'
     And match rows[0].balance_is_zero == '1'
     # Post-completion: re-fund must still be rejected (status guard holds).
     # Clear idempotency row so we hit the Hasura status filter, not the 200 duplicate path.
-    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = '" + lifecycleContractId + "' AND event_type = 'escrow.funded'")
+    * db.execute("DELETE FROM safetrust.trustless_work_webhook_events WHERE contract_id = '" + lifecycleContractId + "' AND event_type = 'escrow.funded'")
     * def fundAgain = { "contractId": "#(lifecycleContractId)", "signer": "#(approver)", "amount": 1200.00 }
     * def fundAgainStr = JSON.stringify(fundAgain)
     Given path '/api/escrows/fund'
@@ -180,7 +180,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     # Measures initialize → fund → approve-milestone → release-funds (true O(4)).
     # Issue draft skipped approve-milestone; that would only prove O(3) and would
     # not exercise the milestone_approved state at all.
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
     * def start = Java.type('java.lang.System').currentTimeMillis()
 
     # 1) Initialize
@@ -215,8 +215,8 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     Then status 200
 
     # 3) Approve milestone (seed row — initialize does not create milestones)
-    * def timingEscrowId = db.query("SELECT id FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")[0].id
-    * db.execute("INSERT INTO public.escrow_milestones (escrow_id, milestone_id, description, amount, status, tenant_id) VALUES ('" + timingEscrowId + "', 'check_in', 'Timing milestone', 500.0, 'pending', 'safetrust') ON CONFLICT (escrow_id, milestone_id) DO NOTHING")
+    * def timingEscrowId = db.query("SELECT id FROM safetrust.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")[0].id
+    * db.execute("INSERT INTO safetrust.escrow_milestones (escrow_id, milestone_id, description, amount, status, tenant_id) VALUES ('" + timingEscrowId + "', 'check_in', 'Timing milestone', 500.0, 'pending', 'safetrust') ON CONFLICT (escrow_id, milestone_id) DO NOTHING")
     * def approveBody =
     """
     {
@@ -247,16 +247,16 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     * def elapsed = Java.type('java.lang.System').currentTimeMillis() - start
     # O(4) Hasura-backed transitions: should complete < 10s under normal load
     And assert elapsed < 10000
-    * def finalRows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * def finalRows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM safetrust.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
     And match finalRows[0].status == 'completed'
     And match finalRows[0].balance_is_zero == '1'
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
-    * def leftover = db.query("SELECT count(*)::text AS c FROM public.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
+    * def leftover = db.query("SELECT count(*)::text AS c FROM safetrust.trustless_work_escrows WHERE contract_id = '" + timingContractId + "'")
     And match leftover[0].c == '0'
 
   # ── Dispute branch: initialize → fund → dispute → resolve ─────────────────
   Scenario: Dispute branch — fund then dispute then resolve transitions correctly
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
     # Initialize
     * def initBody =
     """
@@ -298,7 +298,7 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     And request disputeStr
     When method POST
     Then status 200
-    * def disputed = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    * def disputed = db.query("SELECT status, balance FROM safetrust.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
     And match disputed[0].status == 'disputed'
     And match disputed[0].balance == '800.0000000'
 
@@ -313,13 +313,13 @@ Feature: Full escrow lifecycle state machine — O(steps) sequential validation
     And request resolveStr
     When method POST
     Then status 200
-    * def resolved = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
+    * def resolved = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN '1' ELSE '0' END) AS balance_is_zero FROM safetrust.trustless_work_escrows WHERE contract_id = '" + disputeContractId + "'")
     And match resolved[0].status == 'resolved'
     And match resolved[0].balance_is_zero == '1'
 
     # Status guard: resolve again must 404 (no longer disputed).
     # Clear idempotency so we exercise status=_eq disputed, not the 200 duplicate path.
-    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = '" + disputeContractId + "' AND event_type = 'escrow.resolved'")
+    * db.execute("DELETE FROM safetrust.trustless_work_webhook_events WHERE contract_id = '" + disputeContractId + "' AND event_type = 'escrow.resolved'")
     Given path '/api/escrows/resolve-dispute'
     And header Content-Type = 'application/json'
     And header x-trustlesswork-signature = trustlessWorkSignature(resolveStr)

--- a/tests/karate/features/escrows/fund.feature
+++ b/tests/karate/features/escrows/fund.feature
@@ -6,7 +6,7 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     # so escrow-created-001 is always reset to status: created, balance: 0
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-users.sql'))
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-escrows.sql'))
-    * db.execute("DELETE FROM public.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded' AND tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded' AND tenant_id = 'safetrust'")
 
   Scenario: Valid fund callback updates status to funded and sets balance
     * def body = { "contractId": "escrow-created-001", "signer": "GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z", "amount": 2500.00 }
@@ -18,7 +18,7 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
+    * def rows = db.query("SELECT status, balance FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
     And match rows[0].status == 'funded'
     And match rows[0].balance == '2500.0000000'
 
@@ -32,7 +32,7 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     When method POST
     Then status 200
     And match response.received == true
-    * def afterFirst = db.query("SELECT status, balance, updated_at FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
+    * def afterFirst = db.query("SELECT status, balance, updated_at FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
     And match afterFirst[0].status == 'funded'
     And match afterFirst[0].balance == '2500.0000000'
     Given path '/api/escrows/fund'
@@ -42,11 +42,11 @@ Feature: POST /api/escrows/fund — TrustlessWork fund confirmation callback
     When method POST
     Then status 200
     And match response.received == true
-    * def afterSecond = db.query("SELECT status, balance, updated_at FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
+    * def afterSecond = db.query("SELECT status, balance, updated_at FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-created-001'")
     And match afterSecond[0].status == 'funded'
     And match afterSecond[0].balance == '2500.0000000'
     And match afterSecond[0].updated_at == afterFirst[0].updated_at
-    * def events = db.query("SELECT processed FROM public.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded' ORDER BY created_at")
+    * def events = db.query("SELECT processed FROM safetrust.trustless_work_webhook_events WHERE contract_id = 'escrow-created-001' AND event_type = 'escrow.funded' ORDER BY created_at")
     And match events == '#[2]'
     And match events[0].processed == '#? _ == "true" || _ == "t" || _ == true'
     And match events[1].processed == '#? _ == "true" || _ == "t" || _ == true'

--- a/tests/karate/features/escrows/initialize.feature
+++ b/tests/karate/features/escrows/initialize.feature
@@ -3,7 +3,7 @@ Feature: POST /api/escrows/initialize — TrustlessWork initialize callback
   Background:
     * url webhookUrl
     * db.execute(karate.read('file:tests/karate/fixtures/seed-test-escrows.sql'))
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id = 'STELLAR_CONTRACT_TEST_001'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE contract_id = 'STELLAR_CONTRACT_TEST_001'")
 
   Scenario: Valid initialize callback inserts new escrow with status created
     * def body =
@@ -26,7 +26,7 @@ Feature: POST /api/escrows/initialize — TrustlessWork initialize callback
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, amount, escrow_type, asset_code FROM public.trustless_work_escrows WHERE contract_id = 'STELLAR_CONTRACT_TEST_001'")
+    * def rows = db.query("SELECT status, amount, escrow_type, asset_code FROM safetrust.trustless_work_escrows WHERE contract_id = 'STELLAR_CONTRACT_TEST_001'")
     And match rows[0].status == 'created'
     And assert rows[0].amount == '2500' || rows[0].amount == '2500.0000000'
     And match rows[0].escrow_type == 'single_release'

--- a/tests/karate/features/escrows/release-funds.feature
+++ b/tests/karate/features/escrows/release-funds.feature
@@ -15,7 +15,7 @@ Feature: POST /api/escrows/release-funds
     When method POST
     Then status 200
     And match response == { received: true }
-    * def rows = db.query("SELECT status, balance FROM public.trustless_work_escrows WHERE contract_id = '" + contractId + "'")
+    * def rows = db.query("SELECT status, balance FROM safetrust.trustless_work_escrows WHERE contract_id = '" + contractId + "'")
     And match rows[0].status == 'completed'
     And assert rows[0].balance == '0' || rows[0].balance == '0.0000000'
 

--- a/tests/karate/features/escrows/resolve-dispute.feature
+++ b/tests/karate/features/escrows/resolve-dispute.feature
@@ -15,7 +15,7 @@ Feature: POST /api/escrows/resolve-dispute — TrustlessWork dispute resolution 
     When method POST
     Then status 200
     And match response.received == true
-    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM public.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
+    * def rows = db.query("SELECT status, (CASE WHEN balance = 0::numeric THEN 1 ELSE 0 END) AS balance_is_zero FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-disputed-001'")
     And match rows[0].status == 'resolved'
     And match rows[0].balance_is_zero == '1'
 

--- a/tests/karate/features/reconciliation/get-escrow-by-contract-ids.feature
+++ b/tests/karate/features/reconciliation/get-escrow-by-contract-ids.feature
@@ -24,7 +24,7 @@ Feature: GET /helper/get-escrow-by-contract-ids — TrustlessWork indexer query 
     # contractId → contract_id, roles.approver → approver,
     # roles.serviceProvider → marker (service provider = hotel/owner),
     # roles.releaseSigner → releaser, balance → balance
-    * def rows = db.query("SELECT contract_id, approver, marker, releaser, balance FROM public.trustless_work_escrows WHERE contract_id IN ('CAATN5DTEST00001', 'CAATN5DTEST00002') ORDER BY contract_id")
+    * def rows = db.query("SELECT contract_id, approver, marker, releaser, balance FROM safetrust.trustless_work_escrows WHERE contract_id IN ('CAATN5DTEST00001', 'CAATN5DTEST00002') ORDER BY contract_id")
     And match rows[0].contract_id == 'CAATN5DTEST00001'
     And match rows[0].approver == '#string'
     And match rows[0].marker == '#string'
@@ -37,14 +37,14 @@ Feature: GET /helper/get-escrow-by-contract-ids — TrustlessWork indexer query 
     Then status 200
     # CAATN5DTEST00002 is seeded with balance=300 in seed-test-escrows.sql
     # After sync, balance should reflect TW's authoritative value (mock returns same)
-    * def rows = db.query("SELECT balance FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00002'")
+    * def rows = db.query("SELECT balance FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00002'")
     And match rows[0].balance == '#string'
     # balance is stored as DECIMAL — cast to string by JDBC driver; validate it is numeric
     And assert parseFloat(rows[0].balance) >= 0
 
   # ── CHUNK_SIZE constraint: 50 IDs per TW API call ─────────────────────────
   Scenario: sync with 50 escrows produces exactly 1 TW API call (1 chunk of 50)
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
     * db.execute(karate.read('file:tests/karate/fixtures/seed-50-escrows.sql'))
     Given path '/reconciliation/sync-escrows'
     When method POST
@@ -55,7 +55,7 @@ Feature: GET /helper/get-escrow-by-contract-ids — TrustlessWork indexer query 
 
   # ── CHUNK_SIZE boundary: 51 IDs → 2 TW API calls ─────────────────────────
   Scenario: sync with 51 escrows produces exactly 2 TW API calls (2 chunks)
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
     * db.execute(karate.read('file:tests/karate/fixtures/seed-51-escrows.sql'))
     Given path '/reconciliation/sync-escrows'
     When method POST
@@ -70,11 +70,11 @@ Feature: GET /helper/get-escrow-by-contract-ids — TrustlessWork indexer query 
     # SafeTrust owns the status field — TW's isActive is informational only.
     # The UPSERT_ESCROW_SQL does not write isActive into status column.
     # This test documents and protects that design decision.
-    * def initialStatus = db.query("SELECT status FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00003'")
+    * def initialStatus = db.query("SELECT status FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00003'")
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200
-    * def postSyncStatus = db.query("SELECT status FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00003'")
+    * def postSyncStatus = db.query("SELECT status FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00003'")
     # Status must not be changed by sync — SafeTrust owns this field
     And match postSyncStatus[0].status == initialStatus[0].status
 
@@ -83,7 +83,7 @@ Feature: GET /helper/get-escrow-by-contract-ids — TrustlessWork indexer query 
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200
-    * def afterSync = db.query("SELECT updated_at FROM public.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00001'")
+    * def afterSync = db.query("SELECT updated_at FROM safetrust.trustless_work_escrows WHERE contract_id = 'CAATN5DTEST00001'")
     # updated_at is set to NOW() by the UPSERT — must differ from pre-sync value
     # (only if the row was actually updated; with mock data returning same values,
     # IS DISTINCT FROM guard fires and updated_at stays unchanged — valid either way)

--- a/tests/karate/features/reconciliation/sync-escrows-chunk-behavior.feature
+++ b/tests/karate/features/reconciliation/sync-escrows-chunk-behavior.feature
@@ -2,7 +2,7 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # The reconciliation engine splits contract IDs into chunks of 50 (CHUNK_SIZE).
   # For n escrows, exactly ⌈n/50⌉ calls are made to TrustlessWork.
-  # Each chunk is upserted into public.trustless_work_escrows via:
+  # Each chunk is upserted into safetrust.trustless_work_escrows via:
   #   INSERT ... ON CONFLICT (contract_id) DO UPDATE ... WHERE IS DISTINCT FROM
   # Unchanged rows produce 0 affected rows — only real changes increment `updated`.
   #
@@ -21,7 +21,7 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # ── Boundary: exactly 0 escrows ───────────────────────────────────────────
   Scenario: sync with 0 seeded escrows returns totalEscrows 0 and skipped 0
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200
@@ -33,8 +33,8 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # ── Boundary: exactly 1 escrow → exactly 1 chunk → 1 TW call ─────────────
   Scenario: sync with 1 escrow produces 1 chunk
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
-    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('CTEST001', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust')")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("INSERT INTO safetrust.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('CTEST001', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust')")
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200
@@ -44,7 +44,7 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # ── Boundary: exactly 50 escrows → exactly 1 chunk (CHUNK_SIZE boundary) ──
   Scenario: sync with exactly 50 escrows produces exactly 1 chunk
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
     * def insertSql = karate.read('file:tests/karate/fixtures/seed-50-escrows.sql')
     * db.execute(insertSql)
     Given path '/reconciliation/sync-escrows'
@@ -55,7 +55,7 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # ── Boundary: 51 escrows → 2 chunks (crosses CHUNK_SIZE boundary) ─────────
   Scenario: sync with 51 escrows produces exactly 2 chunks — O(⌈n/50⌉) verified
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
     * def insertSql = karate.read('file:tests/karate/fixtures/seed-51-escrows.sql')
     * db.execute(insertSql)
     Given path '/reconciliation/sync-escrows'
@@ -66,8 +66,8 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # ── Idempotency: unchanged rows → updated = 0 (IS DISTINCT FROM guard) ────
   Scenario: calling sync twice on unchanged data returns updated 0 on second call
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
-    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('CTEST_IDEM', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust')")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("INSERT INTO safetrust.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('CTEST_IDEM', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust')")
     # First sync
     Given path '/reconciliation/sync-escrows'
     When method POST
@@ -82,7 +82,7 @@ Feature: POST /reconciliation/sync-escrows — chunk processing and Big O correc
 
   # ── Performance baseline: O(n) duration grows linearly ────────────────────
   Scenario: sync with 50 escrows completes within 30 seconds
-    * db.execute("DELETE FROM public.trustless_work_escrows WHERE tenant_id = 'safetrust'")
+    * db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE tenant_id = 'safetrust'")
     * def insertSql = karate.read('file:tests/karate/fixtures/seed-50-escrows.sql')
     * db.execute(insertSql)
     Given path '/reconciliation/sync-escrows'

--- a/tests/karate/features/reconciliation/sync-escrows-performance.feature
+++ b/tests/karate/features/reconciliation/sync-escrows-performance.feature
@@ -29,7 +29,7 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     * def clearPerfFixtures =
     """
     function() {
-      db.execute("DELETE FROM public.trustless_work_escrows WHERE contract_id LIKE 'PERF_TEST_%' OR contract_id LIKE 'SCALE_TEST_%' OR contract_id LIKE 'CTEST_CHUNK_%'");
+      db.execute("DELETE FROM safetrust.trustless_work_escrows WHERE contract_id LIKE 'PERF_TEST_%' OR contract_id LIKE 'SCALE_TEST_%' OR contract_id LIKE 'CTEST_CHUNK_%'");
     }
     """
     * def stashNonBenchmarkEscrows =
@@ -37,13 +37,13 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
     function() {
       // Park other safetrust rows so chunk counts equal ⌈n/50⌉ for this scenario
       // without DELETE-ing shared suite data.
-      db.execute("UPDATE public.trustless_work_escrows SET tenant_id = 'safetrust_perf_stash' WHERE tenant_id = 'safetrust'");
+      db.execute("UPDATE safetrust.trustless_work_escrows SET tenant_id = 'safetrust_perf_stash' WHERE tenant_id = 'safetrust'");
     }
     """
     * def restoreStashedEscrows =
     """
     function() {
-      db.execute("UPDATE public.trustless_work_escrows SET tenant_id = 'safetrust' WHERE tenant_id = 'safetrust_perf_stash'");
+      db.execute("UPDATE safetrust.trustless_work_escrows SET tenant_id = 'safetrust' WHERE tenant_id = 'safetrust_perf_stash'");
     }
     """
     * def teardownPerf =
@@ -65,7 +65,7 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
 
   Scenario: n=1 escrow — baseline O(1) sync duration < 5s
     * prepareBenchmark()
-    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('PERF_TEST_001', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust') ON CONFLICT (contract_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id")
+    * db.execute("INSERT INTO safetrust.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) VALUES ('PERF_TEST_001', 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust') ON CONFLICT (contract_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id")
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200
@@ -93,7 +93,7 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
   Scenario: n=100 escrow — O(n) sync duration < 25s and chunks == 2
     * prepareBenchmark()
     * db.execute(karate.read('file:tests/karate/fixtures/seed-50-escrows.sql'))
-    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_EXTRA_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 50) AS s(i) ON CONFLICT (contract_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id")
+    * db.execute("INSERT INTO safetrust.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'PERF_TEST_EXTRA_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 50) AS s(i) ON CONFLICT (contract_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id")
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200
@@ -105,7 +105,7 @@ Feature: POST /reconciliation/sync-escrows — Big O linear scaling verification
 
   Scenario: n=200 escrow — O(n) scaling ratio vs n=1 must be < 400 (rejects O(n²))
     * prepareBenchmark()
-    * db.execute("INSERT INTO public.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'SCALE_TEST_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 200) AS s(i) ON CONFLICT (contract_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id")
+    * db.execute("INSERT INTO safetrust.trustless_work_escrows (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id) SELECT 'SCALE_TEST_' || LPAD(i::text, 3, '0'), 'GMARKER', 'GAPPROVER', 'GRELEASER', 'single_release', 'created', 'USDC', 100, 'safetrust' FROM generate_series(1, 200) AS s(i) ON CONFLICT (contract_id) DO UPDATE SET tenant_id = EXCLUDED.tenant_id")
     Given path '/reconciliation/sync-escrows'
     When method POST
     Then status 200

--- a/tests/karate/features/reconciliation/sync-escrows.feature
+++ b/tests/karate/features/reconciliation/sync-escrows.feature
@@ -4,7 +4,7 @@ Feature: Reconciliation — POST /reconciliation/sync-escrows
   # Integration tests for the reconciliation endpoint.
   #
   # The webhook service must be running and connected to the test database.
-  # Seed data (at least one row in public.trustless_work_escrows) must be
+  # Seed data (at least one row in safetrust.trustless_work_escrows) must be
   # present for the "happy path" scenario.
   #
   # The TrustlessWork indexer is called live; if unavailable the service

--- a/tests/karate/fixtures/seed-50-escrows.sql
+++ b/tests/karate/fixtures/seed-50-escrows.sql
@@ -1,4 +1,4 @@
-INSERT INTO public.trustless_work_escrows
+INSERT INTO safetrust.trustless_work_escrows
   (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id)
 SELECT
   'CTEST_CHUNK_' || LPAD(i::text, 3, '0'),

--- a/tests/karate/fixtures/seed-51-escrows.sql
+++ b/tests/karate/fixtures/seed-51-escrows.sql
@@ -1,4 +1,4 @@
-INSERT INTO public.trustless_work_escrows
+INSERT INTO safetrust.trustless_work_escrows
   (contract_id, marker, approver, releaser, escrow_type, status, asset_code, amount, tenant_id)
 SELECT
   'CTEST_CHUNK_' || LPAD(i::text, 3, '0'),

--- a/tests/karate/fixtures/seed-test-apartments.sql
+++ b/tests/karate/fixtures/seed-test-apartments.sql
@@ -1,7 +1,7 @@
 -- Seed test apartments
-DELETE FROM public.apartments WHERE id IN ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000003');
+DELETE FROM safetrust.apartments WHERE id IN ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000003');
 
-INSERT INTO public.apartments (
+INSERT INTO safetrust.apartments (
     id, owner_id, name, description, price, warranty_deposit, 
     coordinates, address, is_available, available_from, 
     bedrooms, pet_friendly, category

--- a/tests/karate/fixtures/seed-test-bids.sql
+++ b/tests/karate/fixtures/seed-test-bids.sql
@@ -1,7 +1,7 @@
 -- Seed test bid requests
-DELETE FROM public.bid_requests WHERE id = '11111111-1111-1111-1111-111111111111';
+DELETE FROM safetrust.bid_requests WHERE id = '11111111-1111-1111-1111-111111111111';
 
-INSERT INTO public.bid_requests (
+INSERT INTO safetrust.bid_requests (
     id, apartment_id, tenant_id, current_status, 
     proposed_price, desired_move_in
 ) VALUES

--- a/tests/karate/fixtures/seed-test-escrows.sql
+++ b/tests/karate/fixtures/seed-test-escrows.sql
@@ -1,5 +1,5 @@
 -- seed-test-escrows.sql
--- Test fixture for public.trustless_work_escrows
+-- Test fixture for safetrust.trustless_work_escrows
 -- Aligned with migration: 1731909059420_create_trustless_work_escrows/up.sql
 --
 -- Valid statuses (CHECK constraint):
@@ -11,7 +11,7 @@
 --
 -- Dependency: seed-test-users.sql must run first
 
-DELETE FROM public.trustless_work_escrows
+DELETE FROM safetrust.trustless_work_escrows
 WHERE contract_id IN (
   'escrow-created-001',
   'escrow-pending-001',
@@ -22,7 +22,7 @@ WHERE contract_id IN (
 
 -- status: created
 -- Used by: initialize.feature (duplicate contract_id test), fund.feature
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -50,7 +50,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: pending_funding
 -- Used by: fund handler pre-condition tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -78,7 +78,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: funded
 -- Used by: milestone approval tests, reconciliation sync tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -106,7 +106,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: disputed
 -- Used by: open_dispute.feature, resolve dispute tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -136,7 +136,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: completed
 -- Used by: sync-escrows.feature, reconciliation tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -163,7 +163,7 @@ INSERT INTO public.trustless_work_escrows (
 );
 
 -- Insert milestone for escrow-funded-001
-INSERT INTO public.escrow_milestones (
+INSERT INTO safetrust.escrow_milestones (
   escrow_id,
   milestone_id,
   description,
@@ -190,13 +190,13 @@ SELECT
   NULL,
   '{"type": "check_in"}'::jsonb,
   'safetrust'
-FROM public.trustless_work_escrows 
+FROM safetrust.trustless_work_escrows 
 WHERE contract_id = 'escrow-funded-001';
 
 -- Test escrows for get-escrow-by-contract-ids.feature
 -- Contract IDs CAATN5DTEST00001, CAATN5DTEST00002, CAATN5DTEST00003 used by new scenarios
-DELETE FROM public.trustless_work_escrows WHERE contract_id IN ('CAATN5DTEST00001', 'CAATN5DTEST00002', 'CAATN5DTEST00003');
-INSERT INTO public.trustless_work_escrows (
+DELETE FROM safetrust.trustless_work_escrows WHERE contract_id IN ('CAATN5DTEST00001', 'CAATN5DTEST00002', 'CAATN5DTEST00003');
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id, marker, approver, releaser, escrow_type, status, amount, balance, asset_code, tenant_id
 ) VALUES
   ('CAATN5DTEST00001', 'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z', 'GAPPROVER11111111111111111111111111111111111111111111111111', 'GRELEASER1111111111111111111111111111111111111111111111111', 'single_release', 'funded', 500.00, 300.00, 'USDC', 'safetrust'),

--- a/tests/karate/fixtures/seed-test-escrows.sql
+++ b/tests/karate/fixtures/seed-test-escrows.sql
@@ -1,5 +1,5 @@
 -- seed-test-escrows.sql
--- Test fixture for public.trustless_work_escrows
+-- Test fixture for safetrust.trustless_work_escrows
 -- Aligned with migration: 1731909059420_create_trustless_work_escrows/up.sql
 --
 -- Valid statuses (CHECK constraint):
@@ -11,7 +11,7 @@
 --
 -- Dependency: seed-test-users.sql must run first
 
-DELETE FROM public.trustless_work_webhook_events
+DELETE FROM safetrust.trustless_work_webhook_events
 WHERE contract_id IN (
   'escrow-created-001',
   'escrow-pending-001',
@@ -24,7 +24,7 @@ WHERE contract_id IN (
   'CAATN5DTEST00003'
 );
 
-DELETE FROM public.trustless_work_escrows
+DELETE FROM safetrust.trustless_work_escrows
 WHERE contract_id IN (
   'escrow-created-001',
   'escrow-pending-001',
@@ -35,7 +35,7 @@ WHERE contract_id IN (
 
 -- status: created
 -- Used by: initialize.feature (duplicate contract_id test), fund.feature
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -63,7 +63,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: pending_funding
 -- Used by: fund handler pre-condition tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -91,7 +91,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: funded
 -- Used by: milestone approval tests, reconciliation sync tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -119,7 +119,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: disputed
 -- Used by: open_dispute.feature, resolve dispute tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -149,7 +149,7 @@ INSERT INTO public.trustless_work_escrows (
 
 -- status: completed
 -- Used by: sync-escrows.feature, reconciliation tests
-INSERT INTO public.trustless_work_escrows (
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id,
   marker,
   approver,
@@ -176,7 +176,7 @@ INSERT INTO public.trustless_work_escrows (
 );
 
 -- Insert milestone for escrow-funded-001
-INSERT INTO public.escrow_milestones (
+INSERT INTO safetrust.escrow_milestones (
   escrow_id,
   milestone_id,
   description,
@@ -203,13 +203,13 @@ SELECT
   NULL,
   '{"type": "check_in"}'::jsonb,
   'safetrust'
-FROM public.trustless_work_escrows 
+FROM safetrust.trustless_work_escrows 
 WHERE contract_id = 'escrow-funded-001';
 
 -- Test escrows for get-escrow-by-contract-ids.feature
 -- Contract IDs CAATN5DTEST00001, CAATN5DTEST00002, CAATN5DTEST00003 used by new scenarios
-DELETE FROM public.trustless_work_escrows WHERE contract_id IN ('CAATN5DTEST00001', 'CAATN5DTEST00002', 'CAATN5DTEST00003');
-INSERT INTO public.trustless_work_escrows (
+DELETE FROM safetrust.trustless_work_escrows WHERE contract_id IN ('CAATN5DTEST00001', 'CAATN5DTEST00002', 'CAATN5DTEST00003');
+INSERT INTO safetrust.trustless_work_escrows (
   contract_id, marker, approver, releaser, escrow_type, status, amount, balance, asset_code, tenant_id
 ) VALUES
   ('CAATN5DTEST00001', 'GDQERENWDDSQZS7R7WQZKGESDRXL525W65XHIVZO4QPQCHRILIUQ2J7Z', 'GAPPROVER11111111111111111111111111111111111111111111111111', 'GRELEASER1111111111111111111111111111111111111111111111111', 'single_release', 'funded', 500.00, 300.00, 'USDC', 'safetrust'),

--- a/tests/karate/fixtures/seed-test-reservations.sql
+++ b/tests/karate/fixtures/seed-test-reservations.sql
@@ -1,17 +1,17 @@
 -- status: escrow_created — linked to escrow-created-001
-INSERT INTO public.reservations (
+INSERT INTO safetrust.reservations (
   id, apartment_id, guest_id,
   check_in_date, check_out_date,
   total_amount, asset_code,
   status, escrow_id, tenant_id
 ) VALUES (
   '11111111-0000-0000-0000-000000000002',
-  (SELECT id FROM public.apartments LIMIT 1),
+  (SELECT id FROM safetrust.apartments LIMIT 1),
   'owner-123',
   NOW() + INTERVAL '14 days',
   NOW() + INTERVAL '21 days',
   3200.00, 'USDC',
   'escrow_created',
-  (SELECT id FROM public.trustless_work_escrows WHERE contract_id = 'escrow-created-001'),
+  (SELECT id FROM safetrust.trustless_work_escrows WHERE contract_id = 'escrow-created-001'),
   'safetrust'
 );

--- a/tests/karate/fixtures/seed-test-users.sql
+++ b/tests/karate/fixtures/seed-test-users.sql
@@ -1,7 +1,7 @@
 -- Seed test users
-DELETE FROM public.users WHERE id IN ('owner-123', 'tenant-456', 'other-user', 'host-user-001', 'guest-user-001', 'admin-user-001');
+DELETE FROM safetrust.users WHERE id IN ('owner-123', 'tenant-456', 'other-user', 'host-user-001', 'guest-user-001', 'admin-user-001');
 
-INSERT INTO public.users (id, email, last_seen, firebase_uid) VALUES
+INSERT INTO safetrust.users (id, email, last_seen, firebase_uid) VALUES
 ('owner-123', 'owner@example.com', NOW(), 'owner-123'),
 ('tenant-456', 'tenant@example.com', NOW(), 'tenant-456'),
 ('other-user', 'other@example.com', NOW(), 'other-user'),

--- a/webhook/src/routes/escrows/__tests__/approve-milestone.handler.test.js
+++ b/webhook/src/routes/escrows/__tests__/approve-milestone.handler.test.js
@@ -9,9 +9,9 @@ jest.mock('../../../services/hasura', () => ({
 
 const {
   approveMilestoneHandler,
-  getHasuraEndpoint,
 } = require('../approve-milestone.handler');
 const {
+  getHasuraEndpoint,
   hasuraRequest,
   logAndCheckWebhookEvent,
   markWebhookEventProcessed,
@@ -80,6 +80,9 @@ describe('approveMilestoneHandler', () => {
     hasuraRequest.mockResolvedValueOnce({
       update_trustless_work_escrows: { affected_rows: 1 },
     });
+    hasuraRequest.mockResolvedValueOnce({
+      update_reservations: { returning: [] },
+    });
 
     const req = {
       body: {
@@ -111,6 +114,9 @@ describe('approveMilestoneHandler', () => {
     hasuraRequest.mockResolvedValueOnce({
       update_trustless_work_escrows: { affected_rows: 1 },
     });
+    hasuraRequest.mockResolvedValueOnce({
+      update_reservations: { returning: [] },
+    });
 
     const req = {
       body: {
@@ -124,7 +130,7 @@ describe('approveMilestoneHandler', () => {
 
     await approveMilestoneHandler(req, res);
 
-    expect(hasuraRequest).toHaveBeenCalledTimes(3);
+    expect(hasuraRequest).toHaveBeenCalledTimes(4);
     expect(markWebhookEventProcessed).toHaveBeenCalledWith('event-1');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ received: true });
@@ -172,7 +178,7 @@ describe('approveMilestoneHandler', () => {
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(res.json).toHaveBeenCalledWith({
-      error: 'Escrow or milestone not found',
+      error: 'Escrow not found',
     });
     expect(markWebhookEventProcessed).not.toHaveBeenCalled();
   });

--- a/webhook/src/routes/escrows/approve-milestone.handler.ts
+++ b/webhook/src/routes/escrows/approve-milestone.handler.ts
@@ -143,7 +143,7 @@ export async function approveMilestoneHandler(
 
     const mirrorMutation = `
       mutation MirrorMilestoneToReservation($escrowId: uuid!, $status: String!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: $status

--- a/webhook/src/routes/escrows/approve-milestone.handler.ts
+++ b/webhook/src/routes/escrows/approve-milestone.handler.ts
@@ -127,7 +127,7 @@ export async function approveMilestoneHandler(
 
     const mirrorMutation = `
       mutation MirrorMilestoneToReservation($escrowId: uuid!, $status: String!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: $status

--- a/webhook/src/routes/escrows/dispute.handler.ts
+++ b/webhook/src/routes/escrows/dispute.handler.ts
@@ -71,7 +71,7 @@ export const disputeEscrowHandler = async (
     // 3 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorDisputedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "disputed"

--- a/webhook/src/routes/escrows/dispute.handler.ts
+++ b/webhook/src/routes/escrows/dispute.handler.ts
@@ -86,7 +86,7 @@ export const disputeEscrowHandler = async (
     // 3 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorDisputedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "disputed"

--- a/webhook/src/routes/escrows/fund.handler.ts
+++ b/webhook/src/routes/escrows/fund.handler.ts
@@ -96,7 +96,7 @@ export const fundEscrowHandler = async (
     // 4 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorFundedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "funded"

--- a/webhook/src/routes/escrows/fund.handler.ts
+++ b/webhook/src/routes/escrows/fund.handler.ts
@@ -83,7 +83,7 @@ export const fundEscrowHandler = async (
     // 4 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorFundedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "funded"

--- a/webhook/src/routes/escrows/initialize.handler.ts
+++ b/webhook/src/routes/escrows/initialize.handler.ts
@@ -103,7 +103,7 @@ export const initializeEscrowHandler = async (
     if (reservationId) {
       const linkMutation = `
         mutation LinkEscrowToReservation($reservationId: uuid!, $escrowId: uuid!) {
-          update_safetrust_reservations_by_pk(
+          update_reservations_by_pk(
             pk_columns: { id: $reservationId }
             _set: {
               escrow_id: $escrowId,

--- a/webhook/src/routes/escrows/initialize.handler.ts
+++ b/webhook/src/routes/escrows/initialize.handler.ts
@@ -189,7 +189,7 @@ export const initializeEscrowHandler = async (
     if (reservationId) {
       const linkMutation = `
         mutation LinkEscrowToReservation($reservationId: uuid!, $escrowId: uuid!) {
-          update_safetrust_reservations_by_pk(
+          update_reservations_by_pk(
             pk_columns: { id: $reservationId }
             _set: {
               escrow_id: $escrowId,

--- a/webhook/src/routes/escrows/release-funds.handler.ts
+++ b/webhook/src/routes/escrows/release-funds.handler.ts
@@ -69,7 +69,7 @@ export const releaseFundsHandler = async (
     // 3 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorCompletedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "completed"

--- a/webhook/src/routes/escrows/resolve-dispute.handler.ts
+++ b/webhook/src/routes/escrows/resolve-dispute.handler.ts
@@ -69,7 +69,7 @@ export const resolveDisputeHandler = async (
     // 3 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorResolvedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "resolved"

--- a/webhook/src/routes/escrows/resolve-dispute.handler.ts
+++ b/webhook/src/routes/escrows/resolve-dispute.handler.ts
@@ -81,7 +81,7 @@ export const resolveDisputeHandler = async (
     // 3 — Mirror status to public.reservations
     const mirrorMutation = `
       mutation MirrorResolvedToReservation($escrowId: uuid!) {
-        update_safetrust_reservations(
+        update_reservations(
           where: { escrowId: { _eq: $escrowId } }
           _set: {
             status: "resolved"

--- a/webhook/src/routes/hotel/conversations/__tests__/send.handler.test.js
+++ b/webhook/src/routes/hotel/conversations/__tests__/send.handler.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-jest.mock('../../../../services/db', () => ({
-  query: jest.fn(),
+jest.mock('../../../../services/hasura', () => ({
+  hasuraRequest: jest.fn(),
 }));
 
-const db = require('../../../../services/db');
+const { hasuraRequest } = require('../../../../services/hasura');
 const { sendHotelConversationHandler } = require('../send.handler');
 
 function makeResponse() {
@@ -15,10 +15,8 @@ function makeResponse() {
 }
 
 const ids = {
-  apartmentId: '11111111-1111-4111-8111-111111111111',
-  hostId: '22222222-2222-4222-8222-222222222222',
-  guestId: '33333333-3333-4333-8333-333333333333',
-  senderId: '33333333-3333-4333-8333-333333333333',
+  reservation_id: '11111111-1111-4111-8111-111111111111',
+  sender_id: '33333333-3333-4333-8333-333333333333',
   conversationId: '44444444-4444-4444-8444-444444444444',
   messageId: '55555555-5555-4555-8555-555555555555',
 };
@@ -29,7 +27,7 @@ describe('sendHotelConversationHandler', () => {
   });
 
   it('returns 400 when required fields are missing', async () => {
-    const req = { body: { apartmentId: ids.apartmentId } };
+    const req = { body: { reservation_id: ids.reservation_id } };
     const res = makeResponse();
 
     await sendHotelConversationHandler(req, res);
@@ -43,16 +41,26 @@ describe('sendHotelConversationHandler', () => {
   });
 
   it('finds existing conversation and appends a message', async () => {
-    const createdAt = new Date('2026-07-27T00:00:00.000Z');
-    db.query
-      .mockResolvedValueOnce({ rows: [{ id: ids.conversationId }] })
+    const createdAt = new Date('2026-07-27T00:00:00.000Z').toISOString();
+    hasuraRequest
       .mockResolvedValueOnce({
-        rows: [{ id: ids.messageId, created_at: createdAt }],
+        hotel_industry_conversations: [{ id: ids.conversationId }],
+      })
+      .mockResolvedValueOnce({
+        insert_hotel_industry_messages_one: {
+          id: ids.messageId,
+          conversation_id: ids.conversationId,
+          body: 'Hello from guest',
+          is_automated: false,
+          event_type: null,
+          created_at: createdAt,
+        },
       });
 
     const req = {
       body: {
-        ...ids,
+        reservation_id: ids.reservation_id,
+        sender_id: ids.sender_id,
         body: 'Hello from guest',
       },
     };
@@ -60,52 +68,65 @@ describe('sendHotelConversationHandler', () => {
 
     await sendHotelConversationHandler(req, res);
 
-    expect(db.query).toHaveBeenCalledTimes(2);
-    expect(db.query).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('apartment_id'),
-      [ids.apartmentId, ids.hostId, ids.guestId],
-    );
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(hasuraRequest).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({
-      conversationId: ids.conversationId,
-      messageId: ids.messageId,
-      lastMessageAt: createdAt,
+      message: {
+        id: ids.messageId,
+        conversation_id: ids.conversationId,
+        body: 'Hello from guest',
+        is_automated: false,
+        event_type: null,
+        created_at: createdAt,
+      },
     });
   });
 
   it('creates a conversation when none exists', async () => {
-    const createdAt = new Date('2026-07-27T00:00:00.000Z');
-    const escrowId = '66666666-6666-4666-8666-666666666666';
-    db.query
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ id: ids.conversationId }] })
+    const createdAt = new Date('2026-07-27T00:00:00.000Z').toISOString();
+    const escrowTransactionId = '66666666-6666-4666-8666-666666666666';
+
+    hasuraRequest
       .mockResolvedValueOnce({
-        rows: [{ id: ids.messageId, created_at: createdAt }],
+        hotel_industry_conversations: [],
+      })
+      .mockResolvedValueOnce({
+        insert_hotel_industry_conversations_one: { id: ids.conversationId },
+      })
+      .mockResolvedValueOnce({
+        insert_hotel_industry_messages_one: {
+          id: ids.messageId,
+          conversation_id: ids.conversationId,
+          body: 'First message',
+          is_automated: false,
+          event_type: null,
+          created_at: createdAt,
+        },
       });
 
     const req = {
       body: {
-        ...ids,
+        reservation_id: ids.reservation_id,
+        sender_id: ids.sender_id,
         body: 'First message',
-        escrowId,
+        escrow_transaction_id: escrowTransactionId,
       },
     };
     const res = makeResponse();
 
     await sendHotelConversationHandler(req, res);
 
-    expect(db.query).toHaveBeenCalledTimes(3);
-    expect(db.query).toHaveBeenNthCalledWith(
-      2,
-      expect.stringMatching(/INSERT INTO public\.conversations[\s\S]*apartment_id[\s\S]*escrow_id/),
-      [ids.apartmentId, ids.hostId, ids.guestId, escrowId],
-    );
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(hasuraRequest).toHaveBeenCalledTimes(3);
+    expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({
-      conversationId: ids.conversationId,
-      messageId: ids.messageId,
-      lastMessageAt: createdAt,
+      message: {
+        id: ids.messageId,
+        conversation_id: ids.conversationId,
+        body: 'First message',
+        is_automated: false,
+        event_type: null,
+        created_at: createdAt,
+      },
     });
   });
 });

--- a/webhook/src/services/hotel-conversation-notify.ts
+++ b/webhook/src/services/hotel-conversation-notify.ts
@@ -48,7 +48,7 @@ export async function resolveHotelEscrowParties(
        r.apartment_id,
        host_u.id       AS host_id,
        guest_u.id      AS guest_id
-     FROM public.escrow_transactions et
+     FROM safetrust.escrow_transactions et
      JOIN hotel_industry.reservations res
        ON et.reservation_id = res.id
      JOIN hotel_industry.rooms r

--- a/webhook/src/services/hotel-conversation-notify.ts
+++ b/webhook/src/services/hotel-conversation-notify.ts
@@ -5,10 +5,11 @@ import { query } from './db'
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 interface HotelEscrowParties {
-  apartmentId: string
-  hostId:      string
-  guestId:     string
-  escrowId:    string
+  reservationId: string
+  apartmentId:   string
+  hostId:        string
+  guestId:       string
+  escrowId:      string
 }
 
 interface NotifyHotelEscrowConversationParams {
@@ -18,14 +19,12 @@ interface NotifyHotelEscrowConversationParams {
 }
 
 interface ConversationPayload {
-  apartmentId: string
-  hostId:      string
-  guestId:     string
-  senderId:    string
-  body:        string
-  isAutomated: boolean
-  eventType:   string
-  escrowId:    string
+  reservation_id:         string
+  escrow_transaction_id?: string
+  sender_id:              string
+  body:                   string
+  is_automated?:          boolean
+  event_type?:            string
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -38,12 +37,14 @@ export async function resolveHotelEscrowParties(
   contractId: string
 ): Promise<HotelEscrowParties | null> {
   const result = await query<{
+    reservation_id:        string
     escrow_transaction_id: string
     apartment_id:          string
     host_id:               string
     guest_id:              string
   }>(
     `SELECT
+       res.id          AS reservation_id,
        et.id           AS escrow_transaction_id,
        r.apartment_id,
        host_u.id       AS host_id,
@@ -69,15 +70,16 @@ export async function resolveHotelEscrowParties(
   )
 
   const row = result.rows[0]
-  if (!row?.apartment_id || !row?.host_id || !row?.guest_id) {
+  if (!row?.reservation_id || !row?.apartment_id || !row?.host_id || !row?.guest_id) {
     return null
   }
 
   return {
-    apartmentId: row.apartment_id,
-    hostId:      row.host_id,
-    guestId:     row.guest_id,
-    escrowId:    row.escrow_transaction_id,
+    reservationId: row.reservation_id,
+    apartmentId:   row.apartment_id,
+    hostId:        row.host_id,
+    guestId:       row.guest_id,
+    escrowId:      row.escrow_transaction_id,
   }
 }
 
@@ -109,14 +111,12 @@ export async function notifyHotelEscrowConversation({
     }
 
     const payload: ConversationPayload = {
-      apartmentId: parties.apartmentId,
-      hostId:      parties.hostId,
-      guestId:     parties.guestId,
-      senderId:    parties.guestId,
+      reservation_id:        parties.reservationId,
+      escrow_transaction_id: parties.escrowId,
+      sender_id:             parties.guestId,
       body,
-      isAutomated: true,
-      eventType,
-      escrowId:    parties.escrowId,
+      is_automated:          true,
+      event_type:            eventType,
     }
 
     const internalSecret = process.env.INTERNAL_SERVICE_SECRET


### PR DESCRIPTION
## Summary

Migrates all SafeTrust tenant PostgreSQL tables from the `public` schema to a dedicated `safetrust` schema using a post-hoc `init.sql` strategy migration (`1779300000001_migrate_to_safetrust_schema`). This preserves all existing migration history while establishing proper schema-level namespace isolation and eliminating Hasura GraphQL `custom_name` workarounds.

## Key Changes

### 1. Database Migration & Rollback
- **`migrations/safetrust/1779300000001_migrate_to_safetrust_schema/up.sql`**: Creates `safetrust` schema, moves all 16+ SafeTrust tables and custom functions from `public` to `safetrust`, configures `search_path`, and grants permissions to `postgres`.
- **`migrations/safetrust/1779300000001_migrate_to_safetrust_schema/down.sql`**: Full rollback migration moving all tables and functions back to `public`.
- **`migrations/safetrust/INIT.md`**: Strategy documentation explaining the rationale, non-destructive migration design, and usage instructions.

### 2. Hasura Metadata Updates
- Updated table schema in all SafeTrust table metadata files under `metadata/tenants/safetrust/databases/tables/` from `public` to `safetrust`.
- Updated all array and object relationship target schemas from `public` to `safetrust`.
- Removed `custom_name: safetrust_reservations` workaround from `public_reservations.yaml` so GraphQL queries use standard `reservations` root fields directly.
- Updated function metadata definitions under `metadata/tenants/safetrust/databases/functions/` to target `safetrust`.

### 3. Webhook Route Handlers & Services
- Updated GraphQL mutations across escrow handlers (`fund`, `initialize`, `approve-milestone`, `dispute`, `release-funds`, `resolve-dispute`) from `update_safetrust_reservations` to `update_reservations`.
- Updated SQL query in `hotel-conversation-notify.ts` to reference `safetrust.escrow_transactions`.

### 4. Seeds & Karate Tests
- Updated table references in all seed files under `seeds/safetrust/*.sql` from `public.` to `safetrust.`.
- Updated test fixtures (`tests/karate/fixtures/*.sql`) and direct DB assertions (`tests/karate/features/**/*.feature`) from `public.` to `safetrust.`.

## Verification & Testing

- **Webhook Unit Tests**: Ran `npm test` in `webhook/` — **19/19 test suites passed** (181 passed tests, 0 failed).
- **Migration & Rollback**: Verified `up.sql` moves tables to `safetrust` schema cleanly and `down.sql` reverts back to `public`.

Closes #583 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SafeTrust data operations now run within a dedicated schema while preserving existing functionality.
  * Added rollback support for the schema migration.
  * Improved escrow workflow validation and reservation status synchronization.
  * Updated hotel conversation notifications with consistent response fields and creation status.

* **Bug Fixes**
  * Corrected escrow and reservation updates across lifecycle events.
  * Improved duplicate handling in seed data.

* **Tests**
  * Updated integration and endpoint coverage for schema migration and escrow synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->