### PR TITLE
refac: refactor `start.sh` entrypoint and compose service

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -66,8 +66,8 @@ services:
       HASURA_GRAPHQL_ENDPOINT: http://graphql-engine-test:8080
       PG_DATABASE_URL: postgres://postgres:postgrespassword@postgres_test:5432/postgres
       HASURA_GRAPHQL_ADMIN_SECRET: ${TEST_ADMIN_SECRET:-myadminsecretkey}
+      CONSOLE_PORT: 9696
     working_dir: /app
-    command: hasura console --address 0.0.0.0 --console-port 9696
     ports:
       - "9696:9696"
     depends_on:

--- a/start.sh
+++ b/start.sh
@@ -11,9 +11,10 @@ cd "$HASURA_FOLDER" || {
 
 # Note on socat workaround:
 # The original issue (github.com/hasura/graphql-engine/issues/2824) was filed for Hasura v1.x
-# where internal ports only bound to 127.0.0.1. On Hasura v2.x with --address 0.0.0.0,
-# both the console and CLI API server bind to all interfaces directly, so socat port forwarding
-# is no longer needed.
+# where internal ports only bound to 127.0.0.1. On Hasura v2.x / v2.47.0 with --address 0.0.0.0,
+# both the console (port 9696) and CLI API server (port 9693) bind to all interfaces directly,
+# and the CLI communicates directly with GraphQL Engine via docker networking. Tested and verified
+# on Hasura v2.47.0 / v2.x that the console functions normally without socat port-forwarding proxies.
 
 # Start Hasura console with exec for proper signal handling (replaces PID 1)
 echo "[start.sh] Starting Hasura console..."

--- a/start.sh
+++ b/start.sh
@@ -1,43 +1,27 @@
-#!/bin/bash
-HASURA_FOLDER=/app
-cd $HASURA_FOLDER || {
-    echo "Hasura folder '$HASURA_FOLDER' not found"
+#!/usr/bin/env bash
+# start.sh — Hasura CLI container entrypoint
+# Used by hasura-cli-test in docker-compose-test.yml
+set -euo pipefail
+
+HASURA_FOLDER="${HASURA_FOLDER:-/app}"
+cd "$HASURA_FOLDER" || {
+    echo "❌ Hasura folder '$HASURA_FOLDER' not found"
     exit 1
 }
 
-# Workaround for https://github.com/hasura/graphql-engine/issues/2824#issuecomment-801293056
-socat TCP-LISTEN:8080,fork TCP:graphql-engine:8080 &
-socat TCP-LISTEN:9695,fork,reuseaddr,bind=console TCP:127.0.0.1:9695 &
-socat TCP-LISTEN:9693,fork,reuseaddr,bind=console TCP:127.0.0.1:9693 &
+# Note on socat workaround:
+# The original issue (github.com/hasura/graphql-engine/issues/2824) was filed for Hasura v1.x
+# where internal ports only bound to 127.0.0.1. On Hasura v2.x with --address 0.0.0.0,
+# both the console and CLI API server bind to all interfaces directly, so socat port forwarding
+# is no longer needed.
 
-{
-    # Skip migrations for safetrust since it will be created during tenant deployment
-    echo "Skipping migrations for safetrust database as it will be created during tenant deployment"
-    
-    # Apply only metadata changes (disabled: metadata is already fully built and applied via bin/start)
-    # echo "Applying metadata from metadata/base..."
-    # mkdir -p /tmp/hasura_project
-    # cat > /tmp/hasura_project/config.yaml << EOL
-    # version: 3
-    # metadata_directory: /app/metadata/base
-    # EOL
-    # hasura metadata apply --project /tmp/hasura_project --skip-update-check
-    # rm -rf /tmp/hasura_project
-    
-    # Run console if specified
-    if [[ -v HASURA_RUN_CONSOLE ]]; then
-        echo "Starting console..."
-        hasura console \
-            --log-level DEBUG \
-            --address "127.0.0.1" \
-            --no-browser \
-            --endpoint "$HASURA_GRAPHQL_ENDPOINT" \
-            --admin-secret "$HASURA_GRAPHQL_ADMIN_SECRET" \
-            --console-hge-endpoint "http://127.0.0.1:8080" \
-            --api-host "http://127.0.0.1" \
-            || exit 1
-    else
-        echo "Started without console"
-        tail -f /dev/null
-    fi
-}
+# Start Hasura console with exec for proper signal handling (replaces PID 1)
+echo "[start.sh] Starting Hasura console..."
+exec hasura console \
+    --log-level "${HASURA_LOG_LEVEL:-DEBUG}" \
+    --address "0.0.0.0" \
+    --no-browser \
+    --endpoint "${HASURA_GRAPHQL_ENDPOINT:-http://graphql-engine:8080}" \
+    --admin-secret "${HASURA_GRAPHQL_ADMIN_SECRET:-myadminsecretkey}" \
+    --console-port "${CONSOLE_PORT:-9696}" \
+    --api-port "${API_PORT:-9693}"


### PR DESCRIPTION

- Closes #588

## Description

Refactors `start.sh` from dead code and an unconfigurable zombie container fallback into a clean, minimal entrypoint for the Hasura CLI container service (`hasura-cli-test`). Eliminates hardcoded paths, unused environment conditionals, and obsolete `socat` workarounds from Hasura v1.x while implementing proper Unix signal propagation using `exec`.

## 🌀 Summary of Changes

- **Refactored `start.sh`**:
  - Updated shebang to `#!/usr/bin/env bash` with strict error handling `set -euo pipefail`.
  - Driven folder location via environment variable `HASURA_FOLDER="${HASURA_FOLDER:-/app}"` with fallback and missing-directory error reporting.
  - Replaced command execution with `exec hasura console` so Hasura CLI replaces the shell as PID 1, ensuring SIGTERM/SIGINT signals from `docker compose down` stop the container immediately without hanging.
  - Removed unused `HASURA_RUN_CONSOLE` conditional and zombie `tail -f /dev/null` fallback.
  - Removed dead/commented-out metadata apply blocks.
  - Documented why the legacy `socat` port-forwarding workaround from Hasura v1.x (issue #2824) is no longer required on Hasura v2.x when bound via `--address 0.0.0.0`.
- **Updated `docker-compose-test.yml`**:
  - Removed `command:` override on `hasura-cli-test` so it executes `start.sh` as its container entrypoint.
  - Added `CONSOLE_PORT: 9696` to the `hasura-cli-test` service environment variables.
  - Fixed indentation on `postgres_test` healthcheck retries.

## 🛠 Testing

### Evidence Before Solution
- `start.sh` was unused in all compose services; `docker-compose-test.yml` overrode `command:` directly, `HASURA_RUN_CONSOLE` was never set, and the script would fallback to `tail -f /dev/null`.

### Evidence After Solution
- **Syntax validation**: `bash -n start.sh` passed with exit code 0.
- **Compose validation**: `docker compose -f docker-compose-test.yml config` validated with no schema errors.
- **Live container test**: Built and started `hasura-cli-test` via `docker compose -f docker-compose-test.yml up -d --build hasura-cli-test`. Logs verified:
  ```text
  [start.sh] Starting Hasura console...
  INFO console running at: http://0.0.0.0:9696/
  ```
- **Signal handling**: `docker compose -f docker-compose-test.yml down -v` cleanly and immediately terminated the container without timeout.

---

🎉 Thank you for reviewing this PR! 🎉


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability with stricter configuration and safer path handling.
  * Hasura Console now binds directly to all interfaces using configurable ports and connection settings.
  * Removed the previous port-forwarding workaround and outdated startup behavior.
* **Chores**
  * Standardized the test environment to use port 9696 for the Hasura Console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->