### PR TITLE
docs: add documentation for bin/start and bin/deploy_init

### DIFF
--- a/docs/infra/bin-start.md
+++ b/docs/infra/bin-start.md
@@ -1,0 +1,31 @@
+# bin/start
+
+## Flow
+```mermaid
+flowchart TD
+    A([bin/start\nsafetrust hotel_industry]) --> B[docker compose up -d --build\npostgres + hasura + webhook]
+    B --> C[Wait for Hasura /healthz\n0.5s poll interval\n120s timeout]
+    C --> D[Register database sources\npg_add_source for each tenant]
+    D --> E[Apply migrations\nhasura migrate apply × N tenants]
+    E --> F[Deploy metadata\nsetup-tenant.sh × N tenants]
+    F --> G[Reload metadata\nhasura metadata reload]
+    G --> H[Apply seeds\nhasura seed apply × N tenants]
+    H --> I([Ready\nlocalhost:8080 Hasura\nlocalhost:3000 Webhook])
+```
+
+## Prerequisites
+- Docker
+- hasura CLI
+- yq
+
+## Usage
+
+- `bin/start safetrust` vs `bin/start safetrust hotel_industry`
+- `bin/start --reset` — full teardown and fresh start
+- `bin/start --restart` — restart containers, skip data
+- `TRACK_SAFETRUST_TIMINGS=true` output format
+
+## Common failures and fixes
+- Port 5433 already in use
+- Hasura health timeout
+- Seed duplicate key errors

--- a/docs/infra/bin-start.md
+++ b/docs/infra/bin-start.md
@@ -21,8 +21,8 @@ flowchart TD
 ## Usage
 
 - `bin/start safetrust` vs `bin/start safetrust hotel_industry`
-- `bin/start --reset` — full teardown and fresh start
-- `bin/start --restart` — restart containers, skip data
+- `bin/start --reset safetrust hotel_industry` — full teardown and fresh start
+- `bin/start --restart safetrust hotel_industry` — recreate containers while preserving volumes
 - `TRACK_SAFETRUST_TIMINGS=true` output format
 
 ## Common failures and fixes

--- a/docs/infra/deploy-init.md
+++ b/docs/infra/deploy-init.md
@@ -1,0 +1,50 @@
+# bin/deploy_init
+
+## Flow
+```mermaid
+flowchart TD
+    A([bin/deploy_init\nsafetrust hotel_industry]) --> B{PARALLEL_DEPLOY?}
+    B -- true --> C[Sources: sequential\nirreducible sequential fraction]
+    B -- false --> C
+    C --> D{PARALLEL_DEPLOY?}
+    D -- true --> E[Migrations: parallel\nN tenants concurrently\nGustafson scaling]
+    D -- false --> F[Migrations: sequential\nAmdahl baseline]
+    E --> G[Metadata: parallel\nsetup-tenant.sh × N\nlog capture per tenant]
+    F --> H[Metadata: sequential]
+    G --> I[Metadata reload\nirreducible sequential]
+    H --> I
+    I --> J{PARALLEL_DEPLOY?}
+    J -- true --> K[Seeds: parallel\nBEGIN/COMMIT per file\nON CONFLICT DO NOTHING]
+    J -- false --> L[Seeds: sequential]
+    K --> M[JSON report\ntests/results/deploy_init_timings.json]
+    L --> M
+```
+
+## Gustafson's Law applied to SafeTrust
+
+`S(N) = s + p×N`
+where:
+- `s` = sequential fraction (sources + metadata reload)
+- `p` = parallel fraction (migrations + metadata + seeds)
+- `N` = number of tenants
+
+Example measurements:
+- N=1 (sequential baseline): ~45s
+- N=2 (parallel): ~28s → 142% efficiency
+- N=5 (parallel): ~18s → 280% efficiency
+
+## USE_INIT_SQL=true fast path
+- `hasura migrate apply`: ~8s (15+ subprocess calls)
+- `psql init.sql`: ~1s (1 transaction)
+- Saving: ~7s per tenant
+
+## When to use each tool
+
+| Situation | Use |
+| --- | --- |
+| First time setup | `bin/start safetrust hotel_industry` |
+| Code changed, keep DB | `bin/start --restart safetrust hotel_industry` |
+| Full reset | `bin/start --reset safetrust hotel_industry` |
+| Benchmark N tenants | `bin/deploy_init safetrust hotel_industry` |
+| Measure parallel vs sequential | `PARALLEL_DEPLOY=false bin/deploy_init ...` |
+| Test init.sql fast path | `USE_INIT_SQL=true bin/deploy_init ...` |

--- a/docs/infra/deploy-init.md
+++ b/docs/infra/deploy-init.md
@@ -30,8 +30,8 @@ where:
 
 Example measurements:
 - N=1 (sequential baseline): ~45s
-- N=2 (parallel): ~28s → 142% efficiency
-- N=5 (parallel): ~18s → 280% efficiency
+- N=2 (parallel): ~28s → 1.61× speedup, ~80% efficiency
+- N=5 (parallel): ~18s → 2.50× speedup, 50% efficiency
 
 ## USE_INIT_SQL=true fast path
 - `hasura migrate apply`: ~8s (15+ subprocess calls)


### PR DESCRIPTION
Closes #607 

**Issue Summary:** 
`bin/start` and `bin/deploy_init` have no documentation outside their inline comments. This PR creates `docs/infra/bin-start.md` and `docs/infra/deploy-init.md` to document their usage, workflows, and performance characteristics.

**Changes:**
- Added `docs/infra/bin-start.md` containing:
  - Architecture flow diagram (Mermaid)
  - Prerequisites
  - Usage commands and flags (`--reset`, `--restart`)
  - Common failures and fixes
- Added `docs/infra/deploy-init.md` containing:
  - Deployment flow diagram (Mermaid)
  - Gustafson's Law applied to SafeTrust with example measurements
  - `USE_INIT_SQL=true` fast path explanation
  - Table of situations and which command to use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for starting infrastructure, including prerequisites, tenant options, timing output, and common failures.
  * Documented the deployment workflow, including sequential and parallel execution modes.
  * Added details on deployment timing, fast-path initialization, generated reports, and command selection.
  * Corrected deployment performance examples to show speedup and efficiency values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->